### PR TITLE
Add a swipe-to-start feature

### DIFF
--- a/app/src/main/java/com/smouldering_durtles/wk/activities/MainActivity.java
+++ b/app/src/main/java/com/smouldering_durtles/wk/activities/MainActivity.java
@@ -98,7 +98,7 @@ public final class MainActivity extends AbstractActivity implements SwipingScrol
         final ViewProxy startLessonsButton = new ViewProxy(this, R.id.startLessonsButton);
         final ViewProxy startReviewsButton = new ViewProxy(this, R.id.startReviewsButton);
         final ViewProxy resumeButton = new ViewProxy(this, R.id.resumeButton);
-        final ViewProxy swipingScrollView = new ViewProxy(this, R.id.swipingScrollView);
+        final ViewProxy swipingScrollView = new ViewProxy(this, R.id.scrollView);
 
         retryApiErrorButton1.setOnClickListener(v -> retryApiError());
         retryApiErrorButton2.setOnClickListener(v -> retryApiError());

--- a/app/src/main/java/com/smouldering_durtles/wk/activities/MainActivity.java
+++ b/app/src/main/java/com/smouldering_durtles/wk/activities/MainActivity.java
@@ -20,6 +20,7 @@ import static com.smouldering_durtles.wk.util.ObjectSupport.runAsync;
 import static com.smouldering_durtles.wk.util.ObjectSupport.safe;
 
 import android.os.Bundle;
+import android.view.View;
 
 import com.smouldering_durtles.wk.GlobalSettings;
 import com.smouldering_durtles.wk.R;
@@ -55,6 +56,7 @@ import com.smouldering_durtles.wk.views.LiveRecentUnlocksSubjectTableView;
 import com.smouldering_durtles.wk.views.Post60ProgressView;
 import com.smouldering_durtles.wk.views.SessionButtonsView;
 import com.smouldering_durtles.wk.views.SrsBreakDownView;
+import com.smouldering_durtles.wk.views.SwipingScrollView;
 import com.smouldering_durtles.wk.views.SyncProgressView;
 import com.smouldering_durtles.wk.views.TimeLineBarChart;
 import com.smouldering_durtles.wk.views.UpcomingReviewsView;
@@ -70,7 +72,7 @@ import javax.annotation.Nullable;
  *     instances.
  * </p>
  */
-public final class MainActivity extends AbstractActivity {
+public final class MainActivity extends AbstractActivity implements SwipingScrollView.OnSwipeListener {
     private final ViewProxy apiErrorView = new ViewProxy();
     private final ViewProxy apiKeyRejectedView = new ViewProxy();
     private final ViewProxy keyboardHelpView = new ViewProxy();
@@ -96,6 +98,7 @@ public final class MainActivity extends AbstractActivity {
         final ViewProxy startLessonsButton = new ViewProxy(this, R.id.startLessonsButton);
         final ViewProxy startReviewsButton = new ViewProxy(this, R.id.startReviewsButton);
         final ViewProxy resumeButton = new ViewProxy(this, R.id.resumeButton);
+        final ViewProxy swipingScrollView = new ViewProxy(this, R.id.swipingScrollView);
 
         retryApiErrorButton1.setOnClickListener(v -> retryApiError());
         retryApiErrorButton2.setOnClickListener(v -> retryApiError());
@@ -105,6 +108,7 @@ public final class MainActivity extends AbstractActivity {
         startLessonsButton.setOnClickListener(v -> startLessonSession());
         startReviewsButton.setOnClickListener(v -> startReviewSession());
         resumeButton.setOnClickListener(v -> resumeSession());
+        swipingScrollView.setSwipeListener(this);
 
         LiveApiState.getInstance().observe(this, t -> safe(() -> {
             apiErrorView.setVisibility(t == ApiState.ERROR);
@@ -333,5 +337,21 @@ public final class MainActivity extends AbstractActivity {
                 goToActivity(SessionActivity.class);
             }
         });
+    }
+
+    @Override
+    public void onSwipeLeft(SwipingScrollView view) {
+
+    }
+
+    @Override
+    public void onSwipeRight(SwipingScrollView view) {
+        final @Nullable SessionButtonsView sessionButtonsView = findViewById(R.id.sessionButtonsView);
+        if (sessionButtonsView != null) {
+            View delegate = sessionButtonsView.getPrimaryButton().getDelegate();
+            if (delegate != null) {
+                delegate.callOnClick();
+            }
+        }
     }
 }

--- a/app/src/main/java/com/smouldering_durtles/wk/views/SessionButtonsView.java
+++ b/app/src/main/java/com/smouldering_durtles/wk/views/SessionButtonsView.java
@@ -136,7 +136,7 @@ public final class SessionButtonsView extends LinearLayout {
         }
 
         // indicate the primary button to the user with an arrow
-        primaryButton.setText(primaryButton.getText() + "→");
+        primaryButton.setText(primaryButton.getText() + " →");
 
         resumeButton.setVisibility(resumeButtonVisible);
         resumeButtonRow.setVisibility(resumeButtonVisible);

--- a/app/src/main/java/com/smouldering_durtles/wk/views/SessionButtonsView.java
+++ b/app/src/main/java/com/smouldering_durtles/wk/views/SessionButtonsView.java
@@ -40,6 +40,7 @@ public final class SessionButtonsView extends LinearLayout {
     private final ViewProxy startLessonsButton = new ViewProxy();
     private final ViewProxy startReviewsButton = new ViewProxy();
     private final ViewProxy startButtonsRow = new ViewProxy();
+    private ViewProxy primaryButton = new ViewProxy();
 
     /**
      * The constructor.
@@ -121,6 +122,22 @@ public final class SessionButtonsView extends LinearLayout {
             resumeButtonVisible = true;
         }
 
+        // remove arrow from whichever button currently has it
+        resumeButton.setText("Resume session");
+        startReviewsButton.setText("Start reviews");
+        startLessonsButton.setText("Start lessons");
+
+        if (resumeButtonVisible) {
+            primaryButton = resumeButton;
+        } else if (startReviewButtonVisible) {
+            primaryButton = startReviewsButton;
+        } else if (startLessonButtonVisible) {
+            primaryButton = startLessonsButton;
+        }
+
+        // indicate the primary button to the user with an arrow
+        primaryButton.setText(primaryButton.getText() + "→");
+
         resumeButton.setVisibility(resumeButtonVisible);
         resumeButtonRow.setVisibility(resumeButtonVisible);
         startLessonsButton.setVisibility(startLessonButtonVisible);
@@ -149,5 +166,9 @@ public final class SessionButtonsView extends LinearLayout {
             startReviewsButton.disableInteraction();
             resumeButton.disableInteraction();
         });
+    }
+
+    public ViewProxy getPrimaryButton() {
+        return this.primaryButton;
     }
 }

--- a/app/src/main/java/com/smouldering_durtles/wk/views/SwipingScrollView.java
+++ b/app/src/main/java/com/smouldering_durtles/wk/views/SwipingScrollView.java
@@ -124,10 +124,11 @@ public final class SwipingScrollView extends ScrollView {
 
     @Override
     public boolean onInterceptTouchEvent(final MotionEvent ev) {
-        handleTouchEvent(ev);
-        if (ev.getAction() == MotionEvent.ACTION_UP) {
+        boolean accepted = handleTouchEvent(ev);
+        if (accepted) {
             return true;
         }
+
         return super.onInterceptTouchEvent(ev);
     }
 

--- a/app/src/main/java/com/smouldering_durtles/wk/views/SwipingScrollView.java
+++ b/app/src/main/java/com/smouldering_durtles/wk/views/SwipingScrollView.java
@@ -73,7 +73,8 @@ public final class SwipingScrollView extends ScrollView {
         this.swipeListener = swipeListener;
     }
 
-    private void handleTouchEvent(final MotionEvent event) {
+    private boolean handleTouchEvent(final MotionEvent event) {
+        final float density = getContext().getResources().getDisplayMetrics().density;
         if (event.getAction() == MotionEvent.ACTION_DOWN) {
             if (!active) {
                 active = true;
@@ -87,6 +88,17 @@ public final class SwipingScrollView extends ScrollView {
             if (active) {
                 endX = event.getRawX();
                 endY = event.getRawY();
+
+                final float deltaX = endX - startX;
+                final float deltaY = endY - startY;
+                float absX = Math.abs(deltaX);
+                final boolean horizontal = absX > Math.abs(deltaY);
+
+                // If we've gone past a significant threshold, accept the gesture
+                // so that views under us (like buttons) don't also trigger
+                if (horizontal && absX > 10 * density) {
+                    return true;
+                }
             }
         }
         else if (event.getAction() == MotionEvent.ACTION_UP) {
@@ -94,7 +106,6 @@ public final class SwipingScrollView extends ScrollView {
                 active = false;
                 final float deltaX = endX - startX;
                 final float deltaY = endY - startY;
-                final float density = getContext().getResources().getDisplayMetrics().density;
                 final boolean horizontal = Math.abs(deltaX) > Math.abs(deltaY);
                 if (swipeListener != null && horizontal && deltaX < -100 * density) {
                     swipeListener.onSwipeRight(this);
@@ -107,18 +118,27 @@ public final class SwipingScrollView extends ScrollView {
         else if (event.getAction() == MotionEvent.ACTION_CANCEL) {
             active = false;
         }
+
+        return false;
     }
 
     @Override
     public boolean onInterceptTouchEvent(final MotionEvent ev) {
         handleTouchEvent(ev);
+        if (ev.getAction() == MotionEvent.ACTION_UP) {
+            return true;
+        }
         return super.onInterceptTouchEvent(ev);
     }
 
     @SuppressLint("ClickableViewAccessibility")
     @Override
     public boolean onTouchEvent(final MotionEvent ev) {
-        handleTouchEvent(ev);
+        boolean accepted = handleTouchEvent(ev);
+        if (accepted) {
+            return true;
+        }
+
         return super.onTouchEvent(ev);
     }
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -180,123 +180,117 @@
         android:layout_marginBottom="8dp"
         android:visibility="gone"/>
 
-    <androidx.core.widget.NestedScrollView
+    <com.smouldering_durtles.wk.views.SwipingScrollView
+        android:id="@+id/scrollView"
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_weight="1">
 
-        <com.smouldering_durtles.wk.views.SwipingScrollView
-            android:id="@+id/swipingScrollView"
+        <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content">
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:padding="8dp">
 
-            <LinearLayout
+            <com.smouldering_durtles.wk.views.LevelDurationView
+                android:id="@+id/levelDurationView"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="vertical"
-                android:padding="8dp">
+                android:gravity="center_horizontal" />
 
-                <com.smouldering_durtles.wk.views.LevelDurationView
-                    android:id="@+id/levelDurationView"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:gravity="center_horizontal" />
+            <com.smouldering_durtles.wk.views.AvailableSessionsView
+                android:id="@+id/availableSessionsView"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp" />
 
-                <com.smouldering_durtles.wk.views.AvailableSessionsView
-                    android:id="@+id/availableSessionsView"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="4dp" />
+            <com.smouldering_durtles.wk.views.UpcomingReviewsView
+                android:id="@+id/upcomingReviewsView"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="2dp"
+                android:gravity="center_horizontal"
+                android:text="" />
 
-                <com.smouldering_durtles.wk.views.UpcomingReviewsView
-                    android:id="@+id/upcomingReviewsView"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="2dp"
-                    android:gravity="center_horizontal"
-                    android:text="" />
+            <com.smouldering_durtles.wk.views.SyncProgressView
+                android:id="@+id/syncProgressView"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="2dp"
+                android:gravity="center_horizontal"
+                android:text="" />
 
-                <com.smouldering_durtles.wk.views.SyncProgressView
-                    android:id="@+id/syncProgressView"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="2dp"
-                    android:gravity="center_horizontal"
-                    android:text="" />
+            <com.smouldering_durtles.wk.views.SessionButtonsView
+                android:id="@+id/sessionButtonsView"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp" />
 
-                <com.smouldering_durtles.wk.views.SessionButtonsView
-                    android:id="@+id/sessionButtonsView"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="4dp" />
+            <com.smouldering_durtles.wk.views.LessonReviewBreakdownView
+                android:id="@+id/lessonReviewBreakdownView"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:padding="4dp"
+                android:visibility="gone" />
 
-                <com.smouldering_durtles.wk.views.LessonReviewBreakdownView
-                    android:id="@+id/lessonReviewBreakdownView"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="8dp"
-                    android:padding="4dp"
-                    android:visibility="gone" />
+            <com.smouldering_durtles.wk.views.TimeLineBarChart
+                android:id="@+id/timeLineBarChart"
+                android:layout_width="match_parent"
+                android:layout_height="150dp"
+                android:layout_marginTop="8dp" />
 
-                <com.smouldering_durtles.wk.views.TimeLineBarChart
-                    android:id="@+id/timeLineBarChart"
-                    android:layout_width="match_parent"
-                    android:layout_height="150dp"
-                    android:layout_marginTop="8dp" />
+            <com.smouldering_durtles.wk.views.SrsBreakDownView
+                android:id="@+id/srsBreakDownView"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp" />
 
-                <com.smouldering_durtles.wk.views.SrsBreakDownView
-                    android:id="@+id/srsBreakDownView"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="8dp" />
+            <com.smouldering_durtles.wk.views.LevelProgressView
+                android:id="@+id/levelProgressView"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp" />
 
-                <com.smouldering_durtles.wk.views.LevelProgressView
-                    android:id="@+id/levelProgressView"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="8dp" />
+            <com.smouldering_durtles.wk.views.Post60ProgressView
+                android:id="@+id/post60ProgressView"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:visibility="gone" />
 
-                <com.smouldering_durtles.wk.views.Post60ProgressView
-                    android:id="@+id/post60ProgressView"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="8dp"
-                    android:visibility="gone" />
+            <com.smouldering_durtles.wk.views.JoyoProgressView
+                android:id="@+id/joyoProgressView"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp" />
 
-                <com.smouldering_durtles.wk.views.JoyoProgressView
-                    android:id="@+id/joyoProgressView"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="8dp" />
+            <com.smouldering_durtles.wk.views.JlptProgressView
+                android:id="@+id/jlptProgressView"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp" />
 
-                <com.smouldering_durtles.wk.views.JlptProgressView
-                    android:id="@+id/jlptProgressView"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="8dp" />
+            <com.smouldering_durtles.wk.views.LiveRecentUnlocksSubjectTableView
+                android:id="@+id/recentUnlocksView"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp" />
 
-                <com.smouldering_durtles.wk.views.LiveRecentUnlocksSubjectTableView
-                    android:id="@+id/recentUnlocksView"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="8dp" />
+            <com.smouldering_durtles.wk.views.LiveCriticalConditionSubjectTableView
+                android:id="@+id/criticalConditionView"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp" />
 
-                <com.smouldering_durtles.wk.views.LiveCriticalConditionSubjectTableView
-                    android:id="@+id/criticalConditionView"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="8dp" />
+            <com.smouldering_durtles.wk.views.LiveBurnedItemsSubjectTableView
+                android:id="@+id/burnedItemsView"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp" />
 
-                <com.smouldering_durtles.wk.views.LiveBurnedItemsSubjectTableView
-                    android:id="@+id/burnedItemsView"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="8dp" />
+        </LinearLayout>
 
-            </LinearLayout>
-
-        </com.smouldering_durtles.wk.views.SwipingScrollView>
-
-    </androidx.core.widget.NestedScrollView>
+    </com.smouldering_durtles.wk.views.SwipingScrollView>
 
 </LinearLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -185,110 +185,117 @@
         android:layout_height="0dp"
         android:layout_weight="1">
 
-        <LinearLayout
+        <com.smouldering_durtles.wk.views.SwipingScrollView
+            android:id="@+id/swipingScrollView"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:padding="8dp"
-            android:orientation="vertical">
+            android:layout_height="wrap_content">
 
-            <com.smouldering_durtles.wk.views.LevelDurationView
-                android:id="@+id/levelDurationView"
+            <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:gravity="center_horizontal"/>
+                android:orientation="vertical"
+                android:padding="8dp">
 
-            <com.smouldering_durtles.wk.views.AvailableSessionsView
-                android:id="@+id/availableSessionsView"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="4dp"/>
+                <com.smouldering_durtles.wk.views.LevelDurationView
+                    android:id="@+id/levelDurationView"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:gravity="center_horizontal" />
 
-            <com.smouldering_durtles.wk.views.UpcomingReviewsView
-                android:id="@+id/upcomingReviewsView"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="2dp"
-                android:text=""
-                android:gravity="center_horizontal"/>
+                <com.smouldering_durtles.wk.views.AvailableSessionsView
+                    android:id="@+id/availableSessionsView"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="4dp" />
 
-            <com.smouldering_durtles.wk.views.SyncProgressView
-                android:id="@+id/syncProgressView"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="2dp"
-                android:text=""
-                android:gravity="center_horizontal"/>
+                <com.smouldering_durtles.wk.views.UpcomingReviewsView
+                    android:id="@+id/upcomingReviewsView"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="2dp"
+                    android:gravity="center_horizontal"
+                    android:text="" />
 
-            <com.smouldering_durtles.wk.views.SessionButtonsView
-                android:id="@+id/sessionButtonsView"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="4dp"/>
+                <com.smouldering_durtles.wk.views.SyncProgressView
+                    android:id="@+id/syncProgressView"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="2dp"
+                    android:gravity="center_horizontal"
+                    android:text="" />
 
-            <com.smouldering_durtles.wk.views.LessonReviewBreakdownView
-                android:id="@+id/lessonReviewBreakdownView"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
-                android:padding="4dp"
-                android:visibility="gone"/>
+                <com.smouldering_durtles.wk.views.SessionButtonsView
+                    android:id="@+id/sessionButtonsView"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="4dp" />
 
-            <com.smouldering_durtles.wk.views.TimeLineBarChart
-                android:id="@+id/timeLineBarChart"
-                android:layout_width="match_parent"
-                android:layout_height="150dp"
-                android:layout_marginTop="8dp"/>
+                <com.smouldering_durtles.wk.views.LessonReviewBreakdownView
+                    android:id="@+id/lessonReviewBreakdownView"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:padding="4dp"
+                    android:visibility="gone" />
 
-            <com.smouldering_durtles.wk.views.SrsBreakDownView
-                android:id="@+id/srsBreakDownView"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"/>
+                <com.smouldering_durtles.wk.views.TimeLineBarChart
+                    android:id="@+id/timeLineBarChart"
+                    android:layout_width="match_parent"
+                    android:layout_height="150dp"
+                    android:layout_marginTop="8dp" />
 
-            <com.smouldering_durtles.wk.views.LevelProgressView
-                android:id="@+id/levelProgressView"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"/>
+                <com.smouldering_durtles.wk.views.SrsBreakDownView
+                    android:id="@+id/srsBreakDownView"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp" />
 
-            <com.smouldering_durtles.wk.views.Post60ProgressView
-                android:id="@+id/post60ProgressView"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
-                android:visibility="gone"/>
+                <com.smouldering_durtles.wk.views.LevelProgressView
+                    android:id="@+id/levelProgressView"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp" />
 
-            <com.smouldering_durtles.wk.views.JoyoProgressView
-                android:id="@+id/joyoProgressView"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"/>
+                <com.smouldering_durtles.wk.views.Post60ProgressView
+                    android:id="@+id/post60ProgressView"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:visibility="gone" />
 
-            <com.smouldering_durtles.wk.views.JlptProgressView
-                android:id="@+id/jlptProgressView"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"/>
+                <com.smouldering_durtles.wk.views.JoyoProgressView
+                    android:id="@+id/joyoProgressView"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp" />
 
-            <com.smouldering_durtles.wk.views.LiveRecentUnlocksSubjectTableView
-                android:id="@+id/recentUnlocksView"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"/>
+                <com.smouldering_durtles.wk.views.JlptProgressView
+                    android:id="@+id/jlptProgressView"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp" />
 
-            <com.smouldering_durtles.wk.views.LiveCriticalConditionSubjectTableView
-                android:id="@+id/criticalConditionView"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"/>
+                <com.smouldering_durtles.wk.views.LiveRecentUnlocksSubjectTableView
+                    android:id="@+id/recentUnlocksView"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp" />
 
-            <com.smouldering_durtles.wk.views.LiveBurnedItemsSubjectTableView
-                android:id="@+id/burnedItemsView"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"/>
+                <com.smouldering_durtles.wk.views.LiveCriticalConditionSubjectTableView
+                    android:id="@+id/criticalConditionView"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp" />
 
-        </LinearLayout>
+                <com.smouldering_durtles.wk.views.LiveBurnedItemsSubjectTableView
+                    android:id="@+id/burnedItemsView"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp" />
+
+            </LinearLayout>
+
+        </com.smouldering_durtles.wk.views.SwipingScrollView>
 
     </androidx.core.widget.NestedScrollView>
 

--- a/app/src/main/res/layout/fragment_answered_question.xml
+++ b/app/src/main/res/layout/fragment_answered_question.xml
@@ -76,14 +76,14 @@
 
                 <Button
                     android:id="@+id/nextButton"
+                    style="@style/WK.Button.Borderless.Light"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="Next"
-                    android:paddingBottom="4dp"
-                    app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintEnd_toEndOf="parent"
                     android:gravity="end|bottom"
-                    style="@style/WK.Button.Borderless.Light"/>
+                    android:paddingBottom="4dp"
+                    android:text="Next →"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent" />
 
                 <Button
                     android:id="@+id/specialButton1"

--- a/app/src/main/res/layout/fragment_lesson.xml
+++ b/app/src/main/res/layout/fragment_lesson.xml
@@ -29,10 +29,10 @@
 
         <Button
             android:id="@+id/previousButton"
+            style="@style/WK.Button.Normal"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Previous"
-            style="@style/WK.Button.Normal"/>
+            android:text="← Previous" />
 
         <androidx.legacy.widget.Space
             android:layout_width="0dp"
@@ -54,10 +54,10 @@
 
         <Button
             android:id="@+id/nextButton"
+            style="@style/WK.Button.Normal"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Next"
-            style="@style/WK.Button.Normal"/>
+            android:text="Next →" />
 
     </LinearLayout>
 

--- a/app/src/main/res/layout/fragment_summary.xml
+++ b/app/src/main/res/layout/fragment_summary.xml
@@ -30,12 +30,12 @@
 
         <Button
             android:id="@+id/finishButton"
+            style="@style/WK.Button.Normal"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Finish"
+            android:text="Finish →"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            style="@style/WK.Button.Normal"/>
+            app:layout_constraintTop_toTopOf="parent" />
 
         <Button
             android:id="@+id/showButton"


### PR DESCRIPTION
I originally wanted to add a "Continue" button on the session summary page (kind of like what Wanikani web has), but it turned out to be far too difficult to handle all the race conditions caused when starting a new session immediately after finishing one.

So this does the next best thing. It adds a SwipingScrollView to the MainActivity (the diff is giant because of indentation changes), and triggers the first available action (in the following order) when swiping right:
- Resume session
- Start reviews
- Start lessions

I also added a → symbol to all the buttons that can be triggered by swiping right. If you can think of a sensible place to write that down so users will be aware of the functionality, let me know. Otherwise, it'll just have to be a hidden gem :smile: 