### PR TITLE
Enable `shake_on_matching_kanji` by default

### DIFF
--- a/app/src/main/java/com/smouldering_durtles/wk/GlobalSettings.java
+++ b/app/src/main/java/com/smouldering_durtles/wk/GlobalSettings.java
@@ -3248,7 +3248,7 @@ public final class GlobalSettings {
             if (!getAdvancedEnabled()) {
                 return false;
             }
-            return prefs().getBoolean("shake_on_matching_kanji", false);
+            return prefs().getBoolean("shake_on_matching_kanji", true);
         }
 
         /**

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -1206,7 +1206,7 @@
                 app:title="Soft-reject on single-kanji vocabulary"
                 app:singleLineTitle="false"
                 app:summary="If an incorrect reading is an alternative reading for the kanji, do a shake-and-retry instead of failing"
-                app:defaultValue="false"/>
+                app:defaultValue="true"/>
 
             <SwitchPreferenceCompat
                 app:key="full_session_log"


### PR DESCRIPTION
As a user raised in Issue #34, this is the current behavior in the website, which we shouldn't hide away behind an advanced option.