### PR TITLE
Restored text to previous button in lessons

### DIFF
--- a/app/src/main/res/layout/fragment_lesson.xml
+++ b/app/src/main/res/layout/fragment_lesson.xml
@@ -33,7 +33,8 @@
             android:id="@+id/previousButton"
             style="@style/WK.Button.Normal"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content"/>
+            android:layout_height="wrap_content"
+            android:text="Previous" />
 
         <androidx.legacy.widget.Space
             android:layout_width="0dp"


### PR DESCRIPTION
Minor fix restoring the text for this button that got removed in the previous version. Addresses #72 