### PR TITLE
Add onSwipeLeft back to SwipingScrollView

### DIFF
--- a/app/src/main/java/com/smouldering_durtles/wk/fragments/AnsweredSessionFragment.java
+++ b/app/src/main/java/com/smouldering_durtles/wk/fragments/AnsweredSessionFragment.java
@@ -293,6 +293,12 @@ public final class AnsweredSessionFragment extends AbstractSessionFragment imple
         });
     }
 
+    @Override
+    public void onSwipeLeft(SwipingScrollView view) {
+        // Do nothing (match previous behavior before this fragment became a SwipingScrollView)
+    }
+
+    @Override
     public void onSwipeRight(SwipingScrollView view) {
         this.advanceNext(view);
     }

--- a/app/src/main/java/com/smouldering_durtles/wk/fragments/LessonSessionFragment.java
+++ b/app/src/main/java/com/smouldering_durtles/wk/fragments/LessonSessionFragment.java
@@ -207,6 +207,19 @@ public final class LessonSessionFragment extends AbstractSessionFragment impleme
     }
 
     @Override
+    public void onSwipeLeft(final SwipingScrollView view) {
+        safe(() -> {
+            if (!interactionEnabled) {
+                return;
+            }
+            if (!session.isOnFirstLessonItem()) {
+                disableInteraction();
+                session.moveToPreviousLessonItem();
+            }
+        });
+    }
+
+    @Override
     public void onSwipeRight(final SwipingScrollView view) {
         safe(() -> {
             if (!interactionEnabled) {

--- a/app/src/main/java/com/smouldering_durtles/wk/fragments/SubjectInfoFragment.java
+++ b/app/src/main/java/com/smouldering_durtles/wk/fragments/SubjectInfoFragment.java
@@ -140,6 +140,25 @@ public final class SubjectInfoFragment extends AbstractFragment implements Swipi
     }
 
     @Override
+    public void onSwipeLeft(final SwipingScrollView view) {
+        final @Nullable AbstractActivity activity = getAbstractActivity();
+        final @Nullable Bundle args = getArguments();
+        if (currentSubject == null || activity == null || args == null) {
+            return;
+        }
+        final long[] ids = args.getLongArray("ids");
+        if (ids == null) {
+            return;
+        }
+        for (int i=1; i<ids.length; i++) {
+            if (ids[i] == currentSubject.getId()) {
+                activity.goToSubjectInfo(ids[i-1], ids, FragmentTransitionAnimation.LTR);
+                break;
+            }
+        }
+    }
+
+    @Override
     public void onSwipeRight(final SwipingScrollView view) {
         final @Nullable AbstractActivity activity = getAbstractActivity();
         final @Nullable Bundle args = getArguments();

--- a/app/src/main/java/com/smouldering_durtles/wk/fragments/SummarySessionFragment.java
+++ b/app/src/main/java/com/smouldering_durtles/wk/fragments/SummarySessionFragment.java
@@ -545,6 +545,12 @@ public final class SummarySessionFragment extends AbstractSessionFragment implem
                 }, result -> Toast.makeText(requireContext(), "Star ratings updated", Toast.LENGTH_SHORT).show())))
                 .create().show();
     }
+
+    @Override
+    public void onSwipeLeft(SwipingScrollView view) {
+        // Do nothing (match behavior in AnsweredSessionFragment)
+    }
+
     @Override
     public void onSwipeRight(SwipingScrollView view) {
         onFinishClick(view);

--- a/app/src/main/java/com/smouldering_durtles/wk/views/SwipingScrollView.java
+++ b/app/src/main/java/com/smouldering_durtles/wk/views/SwipingScrollView.java
@@ -87,7 +87,6 @@ public final class SwipingScrollView extends ScrollView {
             if (active) {
                 endX = event.getRawX();
                 endY = event.getRawY();
-
             }
         }
         else if (event.getAction() == MotionEvent.ACTION_UP) {
@@ -99,6 +98,9 @@ public final class SwipingScrollView extends ScrollView {
                 final boolean horizontal = Math.abs(deltaX) > Math.abs(deltaY);
                 if (swipeListener != null && horizontal && deltaX < -100 * density) {
                     swipeListener.onSwipeRight(this);
+                }
+                if (swipeListener != null && horizontal && deltaX > 100 * density) {
+                    swipeListener.onSwipeLeft(this);
                 }
             }
         }
@@ -124,6 +126,12 @@ public final class SwipingScrollView extends ScrollView {
      * Listener interface for receive swipe events.
      */
     public interface OnSwipeListener {
+
+        /**
+         * Called when a swipe left is detected.
+         * @param view the view triggering the swipe event
+         */
+        void onSwipeLeft(@SuppressWarnings("unused") SwipingScrollView view);
 
         /**
          * Called when a swipe right is detected.


### PR DESCRIPTION
Added `onSwipeLeft` back to `SwipingScrollView` to add back the behavior where swiping left in lessons would take you to the previous lesson item.
Addresses #74 