### PR TITLE
Reverted change to layout_marginTop

### DIFF
--- a/app/src/main/res/layout/fragment_answered_question.xml
+++ b/app/src/main/res/layout/fragment_answered_question.xml
@@ -67,7 +67,7 @@
                     android:id="@+id/srsIndicator"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="-10dp"
+                    android:layout_marginTop="4dp"
                     android:text=""
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"


### PR DESCRIPTION
Reverting change to the SRS indicator to use 4dp instead of -10dp.

This change was included with other changes for the alternative answers toast. I don't understand that part of the code well enough to see if it affects that or not. A quick spot check seems to show that things work as expected, but I'm not able to test this in depth.

Addresses issue #76 