### PR TITLE
Check if kana answers contain the kana that are already part of the vocabulary

### DIFF
--- a/app/src/main/java/com/smouldering_durtles/wk/model/Session.java
+++ b/app/src/main/java/com/smouldering_durtles/wk/model/Session.java
@@ -715,8 +715,9 @@ s     *
             }
 
             // Because the user input and subject can contain both Hiragana and Katakana in addition to Kanji, we convert Katakana to Hiragana for the next check
-            // 〜 and the Katakana ヶ have a special meaning, so it's easier to ignore them
-            String normalizedSubjectCharacters = KanaUtil.convertKatakanaToHiragana(subject.getCharacters().replaceAll("[〜ヶ]", ""));
+            // 〜 and the small Katakana ヶ have a special meaning, so it's easier to ignore/convert them
+            String subjectCharacters = subject.getCharacters().replace("〜", "").replace("ヶ", "か");
+            String normalizedSubjectCharacters = KanaUtil.convertKatakanaToHiragana(subjectCharacters);
             String normalizedAnswer = KanaUtil.convertKatakanaToHiragana(currentAnswer);
 
             // Check if the answer contains the subject's Kana characters in the expected order

--- a/app/src/main/java/com/smouldering_durtles/wk/model/Session.java
+++ b/app/src/main/java/com/smouldering_durtles/wk/model/Session.java
@@ -721,6 +721,13 @@ s     *
                     return AnswerVerdict.NOK_WITH_RETRY;
                 }
             }
+
+            String expectedKana = subject.getCharacters().replaceAll("\\p{Script=Han}+", ".+");
+            boolean foundNecessaryKana = currentAnswer.matches(expectedKana);
+            if (!foundNecessaryKana) {
+                LOGGER.info("End submit: %s didn't find all expected kana", AnswerVerdict.NOK_WITH_RETRY);
+                return AnswerVerdict.NOK_WITH_RETRY;
+            }
         }
 
         final AnswerVerdict verdict = currentQuestion.checkAnswer(matchingKanji, currentAnswer.trim(),

--- a/app/src/main/java/com/smouldering_durtles/wk/model/Session.java
+++ b/app/src/main/java/com/smouldering_durtles/wk/model/Session.java
@@ -715,6 +715,7 @@ s     *
             }
 
             // Because the user input and subject can contain both Hiragana and Katakana in addition to Kanji, we convert Katakana to Hiragana for the next check
+            // 〜 and the Katakana ヶ have a special meaning, so it's easier to ignore them
             String normalizedSubjectCharacters = KanaUtil.convertKatakanaToHiragana(subject.getCharacters().replaceAll("[〜ヶ]", ""));
             String normalizedAnswer = KanaUtil.convertKatakanaToHiragana(currentAnswer);
 

--- a/app/src/main/java/com/smouldering_durtles/wk/model/Session.java
+++ b/app/src/main/java/com/smouldering_durtles/wk/model/Session.java
@@ -715,7 +715,7 @@ s     *
             }
 
             // Because the user input and subject can contain both Hiragana and Katakana in addition to Kanji, we convert Katakana to Hiragana for the next check
-            String normalizedSubjectCharacters = KanaUtil.convertKatakanaToHiragana(subject.getCharacters());
+            String normalizedSubjectCharacters = KanaUtil.convertKatakanaToHiragana(subject.getCharacters()).replace("〜", "");
             String normalizedAnswer = KanaUtil.convertKatakanaToHiragana(currentAnswer);
 
             // Check if the answer contains the subject's Kana characters in the expected order

--- a/app/src/main/java/com/smouldering_durtles/wk/model/Session.java
+++ b/app/src/main/java/com/smouldering_durtles/wk/model/Session.java
@@ -721,7 +721,7 @@ s     *
             String normalizedAnswer = KanaUtil.convertKatakanaToHiragana(currentAnswer);
 
             // Check if the answer contains the subject's Kana characters in the expected order
-            String expectedKana = normalizedSubjectCharacters.replaceAll("\\p{Script=Han}+", ".+");
+            String expectedKana = normalizedSubjectCharacters.replaceAll("[\\p{Script=Han}０-９]+", ".+");
             boolean foundNecessaryKana = normalizedAnswer.matches(expectedKana);
             if (!foundNecessaryKana) {
                 LOGGER.info("End submit: %s didn't find all expected kana", AnswerVerdict.NOK_WITH_RETRY);

--- a/app/src/main/java/com/smouldering_durtles/wk/model/Session.java
+++ b/app/src/main/java/com/smouldering_durtles/wk/model/Session.java
@@ -16,13 +16,7 @@
 
 package com.smouldering_durtles.wk.model;
 
-import static androidx.core.content.ContextCompat.getSystemService;
-
 import android.annotation.SuppressLint;
-import android.content.Context;
-import android.os.Vibrator;
-import android.text.TextUtils;
-import android.util.Log;
 
 import com.smouldering_durtles.wk.GlobalSettings;
 import com.smouldering_durtles.wk.WkApplication;
@@ -53,12 +47,12 @@ import com.smouldering_durtles.wk.livedata.SubjectChangeListener;
 import com.smouldering_durtles.wk.livedata.SubjectChangeWatcher;
 import com.smouldering_durtles.wk.services.JobRunnerService;
 import com.smouldering_durtles.wk.util.AudioUtil;
+import com.smouldering_durtles.wk.util.KanaUtil;
 import com.smouldering_durtles.wk.util.Logger;
 import com.smouldering_durtles.wk.util.PitchInfoUtil;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Deque;
@@ -68,11 +62,9 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
 
-import static com.smouldering_durtles.wk.GlobalSettings.Review.enable_haptic_feedback_success;
 import static com.smouldering_durtles.wk.enums.SessionItemState.ABANDONED;
 import static com.smouldering_durtles.wk.enums.SessionState.ACTIVE;
 import static com.smouldering_durtles.wk.enums.SessionState.FINISHING;
@@ -722,8 +714,13 @@ s     *
                 }
             }
 
-            String expectedKana = subject.getCharacters().replaceAll("\\p{Script=Han}+", ".+");
-            boolean foundNecessaryKana = currentAnswer.matches(expectedKana);
+            // Because the user input and subject can contain both Hiragana and Katakana in addition to Kanji, we convert Katakana to Hiragana for the next check
+            String normalizedSubjectCharacters = KanaUtil.convertKatakanaToHiragana(subject.getCharacters());
+            String normalizedAnswer = KanaUtil.convertKatakanaToHiragana(currentAnswer);
+
+            // Check if the answer contains the subject's Kana characters in the expected order
+            String expectedKana = normalizedSubjectCharacters.replaceAll("\\p{Script=Han}+", ".+");
+            boolean foundNecessaryKana = normalizedAnswer.matches(expectedKana);
             if (!foundNecessaryKana) {
                 LOGGER.info("End submit: %s didn't find all expected kana", AnswerVerdict.NOK_WITH_RETRY);
                 return AnswerVerdict.NOK_WITH_RETRY;

--- a/app/src/main/java/com/smouldering_durtles/wk/model/Session.java
+++ b/app/src/main/java/com/smouldering_durtles/wk/model/Session.java
@@ -715,7 +715,7 @@ s     *
             }
 
             // Because the user input and subject can contain both Hiragana and Katakana in addition to Kanji, we convert Katakana to Hiragana for the next check
-            String normalizedSubjectCharacters = KanaUtil.convertKatakanaToHiragana(subject.getCharacters()).replace("〜", "");
+            String normalizedSubjectCharacters = KanaUtil.convertKatakanaToHiragana(subject.getCharacters().replaceAll("[〜ヶ]", ""));
             String normalizedAnswer = KanaUtil.convertKatakanaToHiragana(currentAnswer);
 
             // Check if the answer contains the subject's Kana characters in the expected order

--- a/app/src/main/java/com/smouldering_durtles/wk/util/KanaUtil.java
+++ b/app/src/main/java/com/smouldering_durtles/wk/util/KanaUtil.java
@@ -1,0 +1,54 @@
+package com.smouldering_durtles.wk.util;
+
+/**
+ * Helper class for converting Kana.
+ */
+public class KanaUtil {
+    private KanaUtil() {
+    }
+
+    /**
+     * Converts all Katakana characters in the provided String to their respective Hiragana versions.
+     * Non-Katakana characters remain the same.
+     *
+     * @param text the text whose Katakana should be converted
+     * @return the new text where all Katakana characters are replaced with Hiragana
+     */
+    public static String convertKatakanaToHiragana(String text) {
+        StringBuilder stringBuilder = new StringBuilder();
+
+        for (char c : text.toCharArray()) {
+            stringBuilder.append(toHiragana(c));
+        }
+
+        return stringBuilder.toString();
+    }
+
+    /**
+     * Converts the provided character into its Hiragana representation if it's a Katakana character.
+     * Otherwise returns the original character.
+     */
+    private static char toHiragana(char c) {
+        if (isFullWidthKatakana(c)) {
+            return (char) (c - 0x60);
+        } else if (isHalfWidthKatakana(c)) {
+            return (char) (c - 0xcf25);
+        }
+
+        return c;
+    }
+
+    /**
+     * Whether this character is a full width Katakana character.
+     */
+    private static boolean isFullWidthKatakana(char c) {
+        return (('\u30a1' <= c) && (c <= '\u30fe'));
+    }
+
+    /**
+     * Whether this character is a half width Katakana character.
+     */
+    private static boolean isHalfWidthKatakana(char c) {
+        return (('\uff66' <= c) && (c <= '\uff9d'));
+    }
+}


### PR DESCRIPTION
**Description**
This is just a personal gripe of mine with Wanikani, but I believe that the app shouldn't accept answers if a user accidentally mistyped something that was already provided in the question.

For example:
夏休み should accept なつやすみ and fail on なつやつみ, but なつやすむ (and everything else not ending in み) should give the user the chance to retry since they clearly just misspelled the last character that has been provided by Wanikani already.

For simplicity's sake, I didn't add a config setting for this behavior, but I can modify the PR if requested. If it's not something that you believe should be added to the app (since it's not a website feature), then that's perfectly fine, but I think it would be a positive addition that could help make reviews less frustrating.

**Implementation**
My implementation makes use of Regex, but the speed shouldn't be an issue here — in fact, you could argue that the for loop just above this addition could be replaced by `currentAnswer.matches("(?:\\p{Script=Katakana}|\\p{Script=Hiragana})+")` as well for better readability. However, that's beyond the scope of this PR.

We take the word that is being asked for (Kanji + Kana) and replace all Kanji greedily with `.+`. If we match the user's answer to this new regex string, we can effectively check if everything that's not part of the Kanji's reading is still present in the expected order. What the user replaced the Kanji with is not relevant to us as long as it's not nothing.

_Update (more info in the comments)_:
Since the question can contain Katakana that users answer with Hiragana and vice versa, it is necessary to convert all Katakana to Hiragana first. Their ASCII codes are fortunately aligned, so this is trivial.

**Drawbacks**
This change prevents users from submitting a pointless answer to fail the question if the vocabulary question contains Kana. However, since there already is a “Don't know” button to submit an empty answer, this shouldn't be a big deal.

Moreover, it might confuse users who are not familiar with this feature.