### PR TITLE
Draw path insead of text for characters to avoid problems with High Contrast Text

### DIFF
--- a/app/src/main/java/com/smouldering_durtles/wk/views/SubjectInfoButtonView.java
+++ b/app/src/main/java/com/smouldering_durtles/wk/views/SubjectInfoButtonView.java
@@ -336,7 +336,9 @@ public final class SubjectInfoButtonView extends View {
                 paint.setShadowLayer(3, 1, 1, Color.BLACK);
                 final int x = getPaddingLeft() + fontPaddingLeft;
                 final int y = getPaddingTop() + fontPaddingTop + textHeight / 2 - (int) (paint.ascent() + paint.descent()) / 2;
-                canvas.drawText(characters, x, y, paint);
+                Path path = new Path();
+                paint.getTextPath(characters, 0, characters.length(), x, y, path);
+                canvas.drawPath(path, paint);
             }
             else {
                 image.setBounds(


### PR DESCRIPTION
See #89 for the issue

Note: You can figure out if High Contrast Test is enable or not, but then you have to send the variable all way from a activity to the view, so the simplest solution just seems to always draw the path. If this causes issues with performance or compatibility I can look into getting that variable all the way down there :D
