### PR TITLE
Added a feature to sync an individual subject

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -64,6 +64,8 @@ dependencies {
 
     annotationProcessor 'androidx.room:room-compiler:2.6.1'
 
+    debugImplementation 'androidx.annotation:annotation:1.7.1'
+
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation 'androidx.multidex:multidex:2.0.1'
     implementation 'androidx.appcompat:appcompat:1.6.1'

--- a/app/src/main/java/com/smouldering_durtles/wk/activities/AbstractActivity.java
+++ b/app/src/main/java/com/smouldering_durtles/wk/activities/AbstractActivity.java
@@ -55,6 +55,7 @@ import com.smouldering_durtles.wk.jobs.AutoSyncNowJob;
 import com.smouldering_durtles.wk.jobs.FlushTasksJob;
 import com.smouldering_durtles.wk.jobs.SettingChangedJob;
 import com.smouldering_durtles.wk.jobs.SyncNowJob;
+import com.smouldering_durtles.wk.jobs.SyncSubjectJob;
 import com.smouldering_durtles.wk.jobs.TickJob;
 import com.smouldering_durtles.wk.livedata.LiveLevelDuration;
 import com.smouldering_durtles.wk.livedata.LiveSessionProgress;
@@ -512,6 +513,12 @@ public abstract class AbstractActivity extends AppCompatActivity implements Shar
             JobRunnerService.schedule(SyncNowJob.class, "");
             return true;
         }
+        if (itemId == R.id.action_sync_subject) {
+            final @Nullable Subject subject = getCurrentSubject();
+            if (subject != null) {
+                JobRunnerService.schedule(SyncSubjectJob.class, Long.toString(subject.getId()));
+            }
+        }
         if (itemId == R.id.action_flush_tasks) {
             new AlertDialog.Builder(this)
                     .setTitle("Flush background tasks?")
@@ -759,6 +766,10 @@ public abstract class AbstractActivity extends AppCompatActivity implements Shar
                 final @Nullable MenuItem studyMaterialsItem = menu.findItem(R.id.action_study_materials);
                 if (studyMaterialsItem != null) {
                     studyMaterialsItem.setVisible(getCurrentSubject() != null && getCurrentSubject().getType().canHaveStudyMaterials());
+                }
+                final @Nullable MenuItem syncItem = menu.findItem(R.id.action_sync_subject);
+                if (syncItem != null) {
+                    syncItem.setVisible(getCurrentSubject() != null);
                 }
             }
         });

--- a/app/src/main/java/com/smouldering_durtles/wk/db/AppDatabase.java
+++ b/app/src/main/java/com/smouldering_durtles/wk/db/AppDatabase.java
@@ -62,6 +62,7 @@ import com.smouldering_durtles.wk.tasks.GetPatchedStudyMaterialsTask;
 import com.smouldering_durtles.wk.tasks.GetReviewStatisticsTask;
 import com.smouldering_durtles.wk.tasks.GetSrsSystemsTask;
 import com.smouldering_durtles.wk.tasks.GetStudyMaterialsTask;
+import com.smouldering_durtles.wk.tasks.GetSubjectTask;
 import com.smouldering_durtles.wk.tasks.GetSubjectsTask;
 import com.smouldering_durtles.wk.tasks.GetSummaryTask;
 import com.smouldering_durtles.wk.tasks.GetUserTask;
@@ -407,6 +408,20 @@ public abstract class AppDatabase extends RoomDatabase {
         }
     }
 
+    /**
+     * Adds a task to fetch the latest information for a specific subject.
+     * @param subjectId The id for the subject to get.
+     */
+    public final void assertGetSubjectTask(String subjectId) {
+        final int count = taskDefinitionDao().getCountByType(GetSubjectTask.class);
+        if (count == 0) {
+            final TaskDefinition taskDefinition = new TaskDefinition();
+            taskDefinition.setTaskClass(GetSubjectTask.class);
+            taskDefinition.setPriority(GetSubjectTask.PRIORITY);
+            taskDefinition.setData(subjectId);
+            taskDefinitionDao().insertTaskDefinition(taskDefinition);
+        }
+    }
     /**
      * Add a task for fetching the assignments endpoint if it doesn't exist already.
      */

--- a/app/src/main/java/com/smouldering_durtles/wk/tasks/ApiTask.java
+++ b/app/src/main/java/com/smouldering_durtles/wk/tasks/ApiTask.java
@@ -355,7 +355,18 @@ public abstract class ApiTask {
             }
             final JsonNode data = body.get("data");
             final JsonParser parser = mapper.treeAsTokens(data);
-            return mapper.readValue(parser, cls);
+            final T value = mapper.readValue(parser, cls);
+
+            if (value instanceof WaniKaniEntity) {
+                if (!body.has("data") || !body.has("data_updated_at") || !body.has("id") || !body.has("object")) {
+                    db.propertiesDao().setApiInError(true);
+                    LiveApiState.getInstance().forceUpdate();
+                    return null;
+                }
+                ((WaniKaniEntity) value).setId(body.get("id").asInt());
+                ((WaniKaniEntity) value).setObject(body.get("object").asText());
+            }
+            return value;
         } catch (final IOException e) {
             LOGGER.error(e, "API data error");
             return null;

--- a/app/src/main/res/menu/generic_options_menu.xml
+++ b/app/src/main/res/menu/generic_options_menu.xml
@@ -103,6 +103,9 @@
     <item android:id="@+id/action_sync_now"
         android:title="Sync now"
         app:showAsAction="never"/>
+    <item android:id="@+id/action_sync_subject"
+        android:title="Sync this subject"
+        app:showAsAction="never" />
     <item android:id="@+id/action_flush_tasks"
         android:title="Flush BG tasks"
         app:showAsAction="never"/>


### PR DESCRIPTION
## Description
Adds the ability to "sync" a subject that you are currently viewing using the single-subject version of the API. This is as shown on [this forum thread](https://community.wanikani.com/t/android-smouldering-durtles-v111-native-app-with-offline-lessons-and-reviews-plus-themes-and-script-like-features/61776/525?u=silverlotus39) with the only real functional change being changing the name from `Sync subject` to `Sync this subject`. 

Mostly identical  to https://github.com/jerryhcooke/smouldering_durtles/pull/97 except I did not need the change to add the `android.graphics.Path` import to `app/src/main/java/com/smouldering_durtles/wk/views/SubjectInfoButtonView.java` since dev does not have commit https://github.com/jerryhcooke/smouldering_durtles/commit/437fbab760c74f98fe2972e08dbf3f7833139340 which included the use of Path without the import.