### PR TITLE
Fix description for English meaning preference

### DIFF
--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -609,7 +609,7 @@
             app:singleLineTitle="false"
             app:defaultValue="false"
             app:isPreferenceVisible="false"
-            app:summary="Enable this to suggest a keyboard language for reading questions"/>
+            app:summary="Enable this to suggest a keyboard language for meaning questions"/>
 
         <SwitchPreferenceCompat
             app:key="ime_hint_reading"


### PR DESCRIPTION
`ime_hint_meaning` was incorrectly using the same text as `ime_hint_reading`.