### PR TITLE
Proposal: Randomize inflection

### DIFF
--- a/app/src/main/java/com/smouldering_durtles/wk/GlobalSettings.java
+++ b/app/src/main/java/com/smouldering_durtles/wk/GlobalSettings.java
@@ -216,6 +216,24 @@ public final class GlobalSettings {
     }
 
     /**
+     * Get the randomize inflection setting for the given combination of session type.
+     *
+     * @param sessionType the type of the current session
+     * @return true if randomize inflection is enabled
+     */
+    public static boolean getRandomizeInflections(final SessionType sessionType) {
+        if (sessionType == LESSON) {
+            return false;
+        }
+        else if (sessionType == REVIEW) {
+            return AdvancedReview.getRandomizeInflections();
+        }
+        else {
+            return AdvancedSelfStudy.getRandomizeInflections();
+        }
+    }
+
+    /**
      * Get the autoplay setting for the given session type.
      *
      * @param sessionType the type of the current session
@@ -2774,6 +2792,29 @@ public final class GlobalSettings {
             }
             return prefs().getInt("review_subjects_kana_vocabulary_max", -1);
         }
+
+        /**
+         * Randomize inflections in review sessions.
+         *
+         * @return the value
+         */
+        private static boolean getRandomizeInflections() {
+            if (!getAdvancedEnabled()) {
+                return false;
+            }
+            return prefs().getBoolean("review_randomize_inflections", false);
+        }
+
+        /**
+         * Randomize inflections in review sessions.
+         *
+         * @param value the value
+         */
+        private static void setRandomizeInflections(final boolean value) {
+            final SharedPreferences.Editor editor = prefs().edit();
+            editor.putBoolean("review_randomize_inflections", value);
+            editor.apply();
+        }
     }
 
     /**
@@ -3100,6 +3141,29 @@ public final class GlobalSettings {
                 return -1;
             }
             return prefs().getInt("self_study_subjects_kana_vocabulary_max", -1);
+        }
+
+        /**
+         * Randomize inflections in self-study sessions.
+         *
+         * @return the value
+         */
+        private static boolean getRandomizeInflections() {
+            if (!getAdvancedEnabled()) {
+                return false;
+            }
+            return prefs().getBoolean("self_study_randomize_inflections", false);
+        }
+
+        /**
+         * Randomize inflections in self-study sessions.
+         *
+         * @param value the value
+         */
+        private static void setRandomizeInflections(final boolean value) {
+            final SharedPreferences.Editor editor = prefs().edit();
+            editor.putBoolean("self_study_randomize_inflections", value);
+            editor.apply();
         }
     }
 

--- a/app/src/main/java/com/smouldering_durtles/wk/fragments/AbstractSessionFragment.java
+++ b/app/src/main/java/com/smouldering_durtles/wk/fragments/AbstractSessionFragment.java
@@ -135,7 +135,7 @@ public abstract class AbstractSessionFragment extends AbstractFragment implement
         final int maxHeight = dp2px(GlobalSettings.Font.getMaxFontSizeQuizText());
         questionText.setTransparent(true);
         questionText.setTypefaceConfiguration(typefaceConfiguration);
-        questionText.setSubject(subject, question);
+        questionText.setSubject(subject, question, session.getType());
         questionText.setMaxSize(maxWidth, maxHeight);
         questionText.setSizeForQuiz(true);
         questionText.setOnClickListener(v -> safe(() -> questionText.setTypefaceConfiguration(TypefaceConfiguration.DEFAULT)));

--- a/app/src/main/java/com/smouldering_durtles/wk/fragments/AbstractSessionFragment.java
+++ b/app/src/main/java/com/smouldering_durtles/wk/fragments/AbstractSessionFragment.java
@@ -135,7 +135,7 @@ public abstract class AbstractSessionFragment extends AbstractFragment implement
         final int maxHeight = dp2px(GlobalSettings.Font.getMaxFontSizeQuizText());
         questionText.setTransparent(true);
         questionText.setTypefaceConfiguration(typefaceConfiguration);
-        questionText.setSubject(subject);
+        questionText.setSubject(subject, question);
         questionText.setMaxSize(maxWidth, maxHeight);
         questionText.setSizeForQuiz(true);
         questionText.setOnClickListener(v -> safe(() -> questionText.setTypefaceConfiguration(TypefaceConfiguration.DEFAULT)));

--- a/app/src/main/java/com/smouldering_durtles/wk/fragments/AnkiSessionFragment.java
+++ b/app/src/main/java/com/smouldering_durtles/wk/fragments/AnkiSessionFragment.java
@@ -297,7 +297,7 @@ public final class AnkiSessionFragment extends AbstractSessionFragment {
         ankiIncorrectButton.setBackgroundColor(ActiveTheme.getAnkiColors()[3]);
 
         answer.setVisibility(showingAnswer);
-        answer.setText(question.getAnkiAnswerRichText(subject));
+        answer.setText(question.getAnkiAnswerRichText(subject, session.getType()));
         answer.setTextSize(GlobalSettings.Font.getFontSizeAnkiAnswer());
         answer.setTextColor(ActiveTheme.getAnkiColors()[4]);
         answer.setBackgroundColor(ActiveTheme.getAnkiColors()[5]);

--- a/app/src/main/java/com/smouldering_durtles/wk/model/Question.java
+++ b/app/src/main/java/com/smouldering_durtles/wk/model/Question.java
@@ -22,6 +22,7 @@ import com.smouldering_durtles.wk.db.model.Subject;
 import com.smouldering_durtles.wk.enums.CloseEnoughAction;
 import com.smouldering_durtles.wk.enums.QuestionType;
 import com.smouldering_durtles.wk.util.InflectionUtil;
+import com.smouldering_durtles.wk.enums.SessionType;
 
 import java.util.Locale;
 
@@ -201,16 +202,20 @@ public final class Question {
      * @param subject the subject for this item
      * @return the text
      */
-    public CharSequence getAnkiAnswerRichText(final Subject subject) {
-        String inflection = getInflection(subject);
+    public CharSequence getAnkiAnswerRichText(final Subject subject, final SessionType sessionType) {
+        String inflection = getInflection(subject, sessionType);
         return type.getAnkiAnswerRichText(subject) + (inflection != null ? " (" + inflection + ")" : "");
     }
 
-    private boolean isVerb(final Subject subject) {
-        return getInflectionForm(subject).contains("verb");
+    private boolean isVerb(final Subject subject, final SessionType sessionType) {
+        return getInflectionForm(subject, sessionType).contains("verb");
     }
 
-    private String getInflectionForm(final Subject subject) {
+    private String getInflectionForm(final Subject subject, final SessionType sessionType) {
+        if (!GlobalSettings.getRandomizeInflections(sessionType)) {
+            return null;
+        }
+
         for (String partOfSpeech : subject.getPartsOfSpeech()) {
             if (partOfSpeech.equals("godan verb") ||
                 partOfSpeech.equals("ichidan verb") || 
@@ -221,37 +226,40 @@ public final class Question {
         return null;
     }
 
-    private String getInflection(final Subject subject) {
+    private String getInflection(final Subject subject, final SessionType sessionType) {
         if (inflection != null) {
             return inflection;
         }
-        if (getInflectionForm(subject) == null) {
+        if (getInflectionForm(subject, sessionType) == null) {
             return null;
         }
 
-        inflection = isVerb(subject) ? InflectionUtil.getRandomVerbConjugation() : InflectionUtil.getRandomAdjectiveDeclension();
+        inflection = isVerb(subject, sessionType) ?
+            InflectionUtil.getRandomVerbConjugation() :
+            InflectionUtil.getRandomAdjectiveDeclension();
         return inflection;
     }
 
-    public @Nullable String getCharacters(final Subject subject) {
+    public @Nullable String getCharacters(final Subject subject, final SessionType sessionType) {
         String characters = subject.getCharacters();
         if (characters == null) {
             return null;
         }
 
-        String inflection = getInflectionForm(subject);
+        String inflection = getInflectionForm(subject, sessionType);
+        String inflectionType = getInflection(subject, sessionType);
         if (inflection == null)
             return characters;
         else if (inflection.equals("godan verb"))
-            return InflectionUtil.getConjugatedVerb(characters, InflectionUtil.VerbType.GODAN, getInflection(subject));
+            return InflectionUtil.getConjugatedVerb(characters, InflectionUtil.VerbType.GODAN, inflectionType);
         else if (inflection.equals("ichidan verb"))
-            return InflectionUtil.getConjugatedVerb(characters, InflectionUtil.VerbType.ICHIDAN, getInflection(subject));
+            return InflectionUtil.getConjugatedVerb(characters, InflectionUtil.VerbType.ICHIDAN, inflectionType);
         else if (inflection.equals("する verb"))
-            return InflectionUtil.getConjugatedVerb(characters, InflectionUtil.VerbType.SURU, getInflection(subject));
+            return InflectionUtil.getConjugatedVerb(characters, InflectionUtil.VerbType.SURU, inflectionType);
         else if (inflection.equals("い adjective"))
-            return InflectionUtil.getDeclinedAdjective(characters, InflectionUtil.AdjectiveType.I, getInflection(subject));
+            return InflectionUtil.getDeclinedAdjective(characters, InflectionUtil.AdjectiveType.I, inflectionType);
         else if (inflection.equals("な adjective"))
-            return InflectionUtil.getDeclinedAdjective(characters, InflectionUtil.AdjectiveType.NA_PLAIN, getInflection(subject));
+            return InflectionUtil.getDeclinedAdjective(characters, InflectionUtil.AdjectiveType.NA_PLAIN, inflectionType);
          else
             return characters;
     }

--- a/app/src/main/java/com/smouldering_durtles/wk/proxy/ViewProxy.java
+++ b/app/src/main/java/com/smouldering_durtles/wk/proxy/ViewProxy.java
@@ -64,6 +64,7 @@ import com.smouldering_durtles.wk.views.SubjectInfoHeadlineView;
 import com.smouldering_durtles.wk.views.SubjectInfoView;
 import com.smouldering_durtles.wk.views.SwipingScrollView;
 import com.smouldering_durtles.wk.views.SynonymRowView;
+import com.smouldering_durtles.wk.enums.SessionType;
 
 import java.lang.ref.WeakReference;
 import java.util.Collection;
@@ -269,13 +270,13 @@ public final class ViewProxy {
     }
 
     public void setSubject(final Subject subject) {
-        setSubject(subject, null);
+        setSubject(subject, null, null);
     }
 
-    public void setSubject(final Subject subject, final Question question) {
+    public void setSubject(final Subject subject, @Nullable final Question question, @Nullable final SessionType sessionType) {
         final @Nullable View delegate = getDelegate();
         if (delegate instanceof SubjectInfoButtonView) {
-            ((SubjectInfoButtonView) delegate).setSubject(subject, question);
+            ((SubjectInfoButtonView) delegate).setSubject(subject, question, sessionType);
         }
         else if (delegate instanceof SubjectInfoHeadlineView) {
             ((SubjectInfoHeadlineView) delegate).setSubject(subject);

--- a/app/src/main/java/com/smouldering_durtles/wk/proxy/ViewProxy.java
+++ b/app/src/main/java/com/smouldering_durtles/wk/proxy/ViewProxy.java
@@ -46,6 +46,7 @@ import com.airbnb.lottie.LottieAnimationView;
 import com.madrapps.pikolo.ColorPicker;
 import com.madrapps.pikolo.listeners.OnColorSelectionListener;
 import com.smouldering_durtles.wk.Actment;
+import com.smouldering_durtles.wk.model.Question;
 import com.smouldering_durtles.wk.db.model.Subject;
 import com.smouldering_durtles.wk.components.CustomMovementMethod;
 import com.smouldering_durtles.wk.model.AdvancedSearchParameters;
@@ -268,9 +269,13 @@ public final class ViewProxy {
     }
 
     public void setSubject(final Subject subject) {
+        setSubject(subject, null);
+    }
+
+    public void setSubject(final Subject subject, final Question question) {
         final @Nullable View delegate = getDelegate();
         if (delegate instanceof SubjectInfoButtonView) {
-            ((SubjectInfoButtonView) delegate).setSubject(subject);
+            ((SubjectInfoButtonView) delegate).setSubject(subject, question);
         }
         else if (delegate instanceof SubjectInfoHeadlineView) {
             ((SubjectInfoHeadlineView) delegate).setSubject(subject);

--- a/app/src/main/java/com/smouldering_durtles/wk/util/InflectionUtil.java
+++ b/app/src/main/java/com/smouldering_durtles/wk/util/InflectionUtil.java
@@ -242,6 +242,7 @@ public class InflectionUtil {
     static {
         adjectiveEndings.put("past", new AdjectiveEnding("かった", "だった", "でした"));
         adjectiveEndings.put("conjunctive", new AdjectiveEnding("くて", "で", "でして"));
+        // FIXME as is, this will show (spoken/written) for い-adjectives, too, which may confuse people
         adjectiveEndings.put("negative (spoken)", new AdjectiveEnding("くない", "じゃない", "じゃありません"));
         adjectiveEndings.put("negative (written)", new AdjectiveEnding("くない", "ではない", "ではありません"));
         adjectiveEndings.put("negative past (spoken)", new AdjectiveEnding("くなかった", "じゃなかった", "じゃありませんでした"));

--- a/app/src/main/java/com/smouldering_durtles/wk/util/InflectionUtil.java
+++ b/app/src/main/java/com/smouldering_durtles/wk/util/InflectionUtil.java
@@ -1,0 +1,275 @@
+/*
+ * Copyright 2024 The Smouldering Durtles Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.smouldering_durtles.wk.util;
+
+import java.util.HashMap;
+import java.util.function.Function;
+
+public class InflectionUtil {
+
+    static class VerbEnding {
+        public StemForm stemForm;
+        public String ending;
+
+        VerbEnding(StemForm stemForm, String ending) {
+            this.stemForm = stemForm;
+            this.ending = ending;
+        }
+
+        String conjugate(String verb, VerbType verbType) {
+            String stem = getStem(verb, verbType);
+            return stem == null ? verb : stem + ending;
+        }
+
+        String getStem(String verb, VerbType verbType) {
+            if (this.stemForm == StemForm.DICTIONARY)
+                return verb;
+
+            String prefix = verb.substring(0, verb.length() - 1);
+            String lastChar = verb.substring(verb.length() - 1, verb.length());
+
+            if (verbType == VerbType.ICHIDAN) {
+                if (!lastChar.equals("る")) return null;
+                if (stemForm == StemForm.TE) return prefix + "て";
+                if (stemForm == StemForm.TA) return prefix + "た";
+                if (stemForm == StemForm.VOLITIONAL) return prefix + "よ";
+                return prefix;
+            }
+
+            if (verbType == VerbType.SURU) {
+                switch (this.stemForm) {
+                    case DICTIONARY: return "する";
+                    case CONJUNCTIVE: return "し";
+                    case NAI: return "しな";
+                    case IMPERATIVE: return "しろ";
+                    case VOLITIONAL: return "しよう";
+                    case TE: return "して";
+                    case TA: return "した";
+                    case HYPOTHETICAL:
+                        // TODO conditional: すれば, potential: できる
+                        return null;
+                }
+            }
+
+            HashMap<String, String[]> endings = new HashMap<>();
+            endings.put("う", new String[] { "い", "わ", "え", "お", "って" });
+            endings.put("つ", new String[] { "ち", "た", "て", "と", "って" });
+            endings.put("る", new String[] { "り", "ら", "れ", "ろ", "って" });
+            endings.put("ぬ", new String[] { "に", "な", "ね", "の", "んで" });
+            endings.put("む", new String[] { "み", "ま", "め", "も", "んで" });
+            endings.put("ぶ", new String[] { "び", "ば", "べ", "ぼ", "んで" });
+            endings.put("く", new String[] { "き", "か", "け", "こ", "いて" });
+            endings.put("ぐ", new String[] { "ぎ", "が", "げ", "ご", "いで" });
+            endings.put("す", new String[] { "し", "さ", "せ", "そ", "して" });
+            Function<StemForm, Integer> formToIndex = form -> {
+                switch (form) {
+                    case CONJUNCTIVE: return 0;
+                    case NAI: return 1;
+                    case IMPERATIVE: return 2;
+                    case VOLITIONAL: return 3;
+                    case TE: return 4;
+                    default: throw new IllegalArgumentException("no index for this form");
+                }
+            };
+
+            if (endings.get(lastChar) == null) return null;
+
+            if (this.stemForm == StemForm.TA) {
+                String teEnding = endings.get(lastChar)[formToIndex.apply(StemForm.TE)];
+                return prefix + teEnding.replace("て", "た").replace("で", "だ");
+            }
+
+            return prefix + endings.get(lastChar)[formToIndex.apply(this.stemForm)];
+        }
+    }
+
+    enum StemForm {
+        DICTIONARY,
+        CONJUNCTIVE,
+        NAI,
+        IMPERATIVE,
+        HYPOTHETICAL,
+        VOLITIONAL,
+        TE,
+        TA,
+    }
+
+    // we leave くる out -- it is not assigned a special verb in wanikani
+    //　just する is also considered a する verb
+    public enum VerbType {
+        ICHIDAN,
+        GODAN,
+        SURU,
+    }
+
+    enum VerbConjugation {
+        NEGATIVE_IMPERATIVE,
+        TE,
+        TAI,
+        PAST,
+        POTENTIAL,
+        PASSIVE,
+        CAUSATIVE,
+        CAUSATIVE_PASSIVE
+    }
+
+    public enum AdjectiveType {
+        I,
+        NA_PLAIN,
+        NA_POLITE
+    }
+
+    static void addDictionary(String name, String ending) {
+        verbEndings.put(name, new VerbEnding(StemForm.DICTIONARY, ending));
+    }
+
+    static void addConjunctive(String name, String ending) {
+        verbEndings.put(name, new VerbEnding(StemForm.CONJUNCTIVE, ending));
+    }
+
+    static void addImperative(String name, String ending) {
+        verbEndings.put(name, new VerbEnding(StemForm.IMPERATIVE, ending));
+    }
+
+    static void addNai(String name, String ending) {
+        verbEndings.put(name, new VerbEnding(StemForm.NAI, ending));
+    }
+
+    static void addTe(String name, String ending) {
+        verbEndings.put(name, new VerbEnding(StemForm.TE, ending));
+    }
+
+    static void addTa(String name, String ending) {
+        verbEndings.put(name, new VerbEnding(StemForm.TA, ending));
+    }
+
+    static HashMap<String, VerbEnding> verbEndings = new HashMap<String, VerbEnding>();
+    static {
+        addConjunctive("polite non past", "ます");
+        addConjunctive("polite past", "ました");
+        addConjunctive("polite negative", "ません");
+        addConjunctive("polite negative past", "ませんでした");
+        addConjunctive("polite imperative", "なさい");
+        addConjunctive("polite imperative, short", "な");
+        addConjunctive("polite volitional", "ましょう");
+        addConjunctive("polite conjunction", "まして");
+
+        addDictionary("nominalization", "こと");
+        addDictionary("sometimes", "ことがある");
+        addDictionary("decide on", "ことにする");
+        addDictionary("is decided", "ことになる");
+
+        addDictionary("\"before\"", "前に");
+
+        addDictionary("hypothetical if", "なら(ば)");
+        addDictionary("if (sure)", "と");
+        addDictionary("\"should be\"", "はず");
+        addDictionary("\"seems like\"", "みたい");
+        addDictionary("\"I hear\"", "そう");
+        addDictionary("\"apparently\"", "らしい");
+
+        addConjunctive("\"[motion] and [do]\"", "に + motion verb");
+        addConjunctive("\"easy to\"", "やすい");
+        addConjunctive("\"difficult to\"", "にくい");
+        addConjunctive("\"too much\"", "すぎる");
+        addConjunctive("speaker's desire", "たい");
+        addConjunctive("someone's desire", "たがる");
+        addConjunctive("\"while\"", "ながら");
+        addConjunctive("\"often\"", "がち");
+        addConjunctive("\"way of\"", "方");
+        addConjunctive("\"looks like ...\"", "そう");
+
+        addNai("negative", "ない");
+        addNai("negative て-form", "なくて");
+        addNai("past negative", "なかった");
+        addNai("\"don't do please\"", "ないでください");
+        addNai("\"without\"", "ないで");
+        addNai("must (informal)", "なきゃ");
+        addNai("must (formal)", "なくてはいけない");
+
+        addImperative("imperative", "");
+
+        addTa("past", "");
+        addTa("\"have before\"", "ことがある");
+
+        addTe("continuing", "いる");
+        addTe("continuing (informal)", "る");
+        addTe("resulting", "ある");
+        addTe("\"try\"", "みる");
+        addTe("\"please\"", "ください");
+    };
+
+    public static String getConjugatedVerb(String verb, VerbType verbType, String endingName) {
+        return verbEndings.get(endingName).conjugate(verb, verbType);
+    }
+
+    static class AdjectiveEnding {
+        String i;
+        String naPlain;
+        String naPolite;
+
+        AdjectiveEnding(String i, String naPlain, String naPolite) {
+            this.i = i;
+            this.naPlain = naPlain;
+            this.naPolite = naPolite;
+        }
+
+        String decline(String adjective, AdjectiveType adjectiveType) {
+            switch (adjectiveType) {
+                case I: return adjective.substring(0, adjective.length() - 1) + i;
+                case NA_PLAIN: return adjective + naPlain;
+                case NA_POLITE: return adjective + naPolite;
+            }
+            return adjective;
+        }
+    }
+
+    static HashMap<String, AdjectiveEnding> adjectiveEndings = new HashMap<String, AdjectiveEnding>();
+    static {
+        adjectiveEndings.put("past", new AdjectiveEnding("かった", "だった", "でした"));
+        adjectiveEndings.put("conjunctive", new AdjectiveEnding("くて", "で", "でして"));
+        adjectiveEndings.put("negative (spoken)", new AdjectiveEnding("くない", "じゃない", "じゃありません"));
+        adjectiveEndings.put("negative (written)", new AdjectiveEnding("くない", "ではない", "ではありません"));
+        adjectiveEndings.put("negative past (spoken)", new AdjectiveEnding("くなかった", "じゃなかった", "じゃありませんでした"));
+        adjectiveEndings.put("negative past (written)", new AdjectiveEnding("くなかった", "ではなかった", "ではありませんでした"));
+        adjectiveEndings.put("negative conjunctive", new AdjectiveEnding("くなくて", "で", "でして"));
+    }
+
+    public static String getDeclinedAdjective(String adjective, AdjectiveType adjectiveType, String declension) {
+        return adjectiveEndings.get(declension).decline(adjective, adjectiveType);
+    }
+
+    public static String getRandomAdjectiveDeclension() {
+        int index = (int) (Math.random() * adjectiveEndings.size());
+        return (String) adjectiveEndings.keySet().toArray()[index];
+    }
+
+    public static String getRandomVerbConjugation() {
+        int index = (int) (Math.random() * verbEndings.size());
+        return (String) verbEndings.keySet().toArray()[index];
+    }
+
+    // for testing purposes
+    public static void main(String[] args) {
+        System.out.println(getDeclinedAdjective("大人しい", AdjectiveType.I, "past"));
+        System.out.println(getDeclinedAdjective("不安", AdjectiveType.NA_PLAIN, "past"));
+        System.out.println(getDeclinedAdjective("不安", AdjectiveType.NA_POLITE, "past"));
+        System.out.println(getConjugatedVerb("集中する", VerbType.SURU, "speaker's desire"));
+        System.out.println(getConjugatedVerb("食", VerbType.ICHIDAN, "speaker's desire"));
+        System.out.println(getConjugatedVerb("飲む", VerbType.GODAN, "past"));
+    }
+}

--- a/app/src/main/java/com/smouldering_durtles/wk/util/InflectionUtil.java
+++ b/app/src/main/java/com/smouldering_durtles/wk/util/InflectionUtil.java
@@ -39,6 +39,22 @@ public class InflectionUtil {
             if (this.stemForm == StemForm.DICTIONARY)
                 return verb;
 
+            if (verbType == VerbType.SURU) {
+                String prefix = verb.endsWith("する") ? verb.substring(0, verb.length() - 2) : verb;
+                switch (this.stemForm) {
+                    case DICTIONARY: return prefix + "する";
+                    case CONJUNCTIVE: return prefix + "し";
+                    case NAI: return prefix + "しな";
+                    case IMPERATIVE: return prefix + "しろ";
+                    case VOLITIONAL: return prefix + "しよう";
+                    case TE: return prefix + "して";
+                    case TA: return prefix + "した";
+                    case HYPOTHETICAL:
+                        // TODO conditional: すれば, potential: できる
+                        return null;
+                }
+            }
+
             String prefix = verb.substring(0, verb.length() - 1);
             String lastChar = verb.substring(verb.length() - 1, verb.length());
 
@@ -48,21 +64,6 @@ public class InflectionUtil {
                 if (stemForm == StemForm.TA) return prefix + "た";
                 if (stemForm == StemForm.VOLITIONAL) return prefix + "よ";
                 return prefix;
-            }
-
-            if (verbType == VerbType.SURU) {
-                switch (this.stemForm) {
-                    case DICTIONARY: return "する";
-                    case CONJUNCTIVE: return "し";
-                    case NAI: return "しな";
-                    case IMPERATIVE: return "しろ";
-                    case VOLITIONAL: return "しよう";
-                    case TE: return "して";
-                    case TA: return "した";
-                    case HYPOTHETICAL:
-                        // TODO conditional: すれば, potential: できる
-                        return null;
-                }
             }
 
             HashMap<String, String[]> endings = new HashMap<>();
@@ -270,6 +271,7 @@ public class InflectionUtil {
         System.out.println(getDeclinedAdjective("不安", AdjectiveType.NA_PLAIN, "past"));
         System.out.println(getDeclinedAdjective("不安", AdjectiveType.NA_POLITE, "past"));
         System.out.println(getConjugatedVerb("集中する", VerbType.SURU, "speaker's desire"));
+        System.out.println(getConjugatedVerb("どきどき", VerbType.SURU, "speaker's desire"));
         System.out.println(getConjugatedVerb("食", VerbType.ICHIDAN, "speaker's desire"));
         System.out.println(getConjugatedVerb("飲む", VerbType.GODAN, "past"));
     }

--- a/app/src/main/java/com/smouldering_durtles/wk/views/SubjectInfoButtonView.java
+++ b/app/src/main/java/com/smouldering_durtles/wk/views/SubjectInfoButtonView.java
@@ -47,6 +47,7 @@ import com.smouldering_durtles.wk.db.model.Subject;
 import com.smouldering_durtles.wk.model.Question;
 import com.smouldering_durtles.wk.model.TypefaceConfiguration;
 import com.smouldering_durtles.wk.util.ViewUtil;
+import com.smouldering_durtles.wk.enums.SessionType;
 
 import java.net.URLEncoder;
 import java.util.Locale;
@@ -399,7 +400,7 @@ public final class SubjectInfoButtonView extends View {
      * @param subject the subject
      */
     public void setSubject(final Subject subject) {
-        setSubject(subject, null);
+        setSubject(subject, null, null);
     }
 
     /**
@@ -407,10 +408,11 @@ public final class SubjectInfoButtonView extends View {
      *
      * @param subject the subject
      * @param question the optional question for this subject
+     * @param question the optional session type this subject appears in
      */
-    public void setSubject(final Subject subject, @Nullable final Question question) {
+    public void setSubject(final Subject subject, @Nullable final Question question, @Nullable SessionType sessionType) {
         safe(() -> {
-            characters = orElse(question != null ? question.getCharacters(subject) : subject.getCharacters(), "");
+            characters = orElse(question != null && sessionType != null ? question.getCharacters(subject, sessionType) : subject.getCharacters(), "");
             image = subject.needsTitleImage() ? ContextCompat.getDrawable(getContext(), subject.getTitleImageId()) : null;
             textColor = subject.getTextColor();
             if (image != null) {

--- a/app/src/main/java/com/smouldering_durtles/wk/views/SubjectInfoButtonView.java
+++ b/app/src/main/java/com/smouldering_durtles/wk/views/SubjectInfoButtonView.java
@@ -44,6 +44,7 @@ import com.smouldering_durtles.wk.Constants;
 import com.smouldering_durtles.wk.GlobalSettings;
 import com.smouldering_durtles.wk.R;
 import com.smouldering_durtles.wk.db.model.Subject;
+import com.smouldering_durtles.wk.model.Question;
 import com.smouldering_durtles.wk.model.TypefaceConfiguration;
 import com.smouldering_durtles.wk.util.ViewUtil;
 
@@ -398,8 +399,18 @@ public final class SubjectInfoButtonView extends View {
      * @param subject the subject
      */
     public void setSubject(final Subject subject) {
+        setSubject(subject, null);
+    }
+
+    /**
+     * Set the subject for this button contextualized by a question.
+     *
+     * @param subject the subject
+     * @param question the optional question for this subject
+     */
+    public void setSubject(final Subject subject, @Nullable final Question question) {
         safe(() -> {
-            characters = orElse(subject.getCharacters(), "");
+            characters = orElse(question != null ? question.getCharacters(subject) : subject.getCharacters(), "");
             image = subject.needsTitleImage() ? ContextCompat.getDrawable(getContext(), subject.getTitleImageId()) : null;
             textColor = subject.getTextColor();
             if (image != null) {

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -1033,6 +1033,13 @@
                 app:useSimpleSummaryProvider="true"
                 app:defaultValue="false"/>
 
+            <SwitchPreferenceCompat
+                app:key="review_randomize_inflections"
+                app:title="Randomize inflections in review"
+                app:singleLineTitle="false"
+                app:defaultValue="false"
+                app:summary="Random inflections will be added to adjectives and verbs. Note that answers and audio will use only dictionary forms. Works best with Anki mode, where you can see the type of inflection added in the answer screen."/>
+
             <com.smouldering_durtles.wk.components.InfoPreference
                 app:title="" app:key="review_subject_selection"/>
             <com.smouldering_durtles.wk.components.NumberRangePreference
@@ -1127,6 +1134,13 @@
                 app:singleLineTitle="false"
                 app:useSimpleSummaryProvider="true"
                 app:defaultValue="false"/>
+
+            <SwitchPreferenceCompat
+                app:key="self_study_randomize_inflections"
+                app:title="Randomize inflections in self-study"
+                app:singleLineTitle="false"
+                app:defaultValue="false"
+                app:summary="Random inflections will be added to adjectives and verbs. Note that answers and audio will use only dictionary forms. Works best with Anki mode, where you can see the type of inflection added in the answer screen."/>
 
             <com.smouldering_durtles.wk.components.InfoPreference
                 app:title="" app:key="self_study_subject_selection"/>


### PR DESCRIPTION
A proposal for a new advanced setting: randomize the inflection of every verb and adjective in review and self-study mode. I noticed that I had trouble recognizing verbs in actual sentences because I only memorized the dictionary forms. This, I hope, will help train recognition in actual use.

Copied from the explanatory text under the setting (please suggest improvements if it is not sufficiently clear :))
> Random inflections will be added to adjectives and verbs. Note that answers and audio will use only dictionary forms. Works best with Anki mode, where you can see the type of inflection added in the answer screen.

If you think this could be a worthwhile addition, it may make sense to ask for support in the forum to extend the list of inflections. I have only rough knowledge of most of the ones I already included.

One additional question: it wasn't clear to me what author to best put for the new [InflectionUtil.java](http://inflectionutil.java/) file. I chose "Copyright 2024 The Smouldering Durtles Authors". Is this alright?

I marked the PR as work-in-progress as I am still testing if everything is looking alright throughout my daily use.