### PR TITLE
feat(settings): Add 'Always hide WaniKani's own mnemonics' option

### DIFF
--- a/app/src/main/java/com/smouldering_durtles/wk/GlobalSettings.java
+++ b/app/src/main/java/com/smouldering_durtles/wk/GlobalSettings.java
@@ -1174,12 +1174,44 @@ public final class GlobalSettings {
         }
 
         /**
+         * Always hide WaniKani's mnemonics regardless of user notes
+         *
+         * @return the value
+         */
+        public static boolean getAlwaysHideWKMnemonic() {
+            return prefs().getBoolean("always_hide_wk_mnemonic", false);
+        }
+
+        /**
+         * Helper method to invert the always_hide_wk_mnemonic preference.
+         * Used for enabling/disabling conditional mnemonic hiding preferences.
+         *
+         * @return true if mnemonics should not always be hidden
+         */
+        public static boolean getNotAlwaysHideWKMnemonic() {
+            return !prefs().getBoolean("always_hide_wk_mnemonic", false);
+        }
+
+        /**
+         * Helper method to invert the always_hide_wk_mnemonic preference.
+         * Used for enabling/disabling conditional mnemonic hiding preferences.
+         *
+         * @param value true if mnemonics should not always be hidden
+         */
+        public static void setNotAlwaysHideWKMnemonic(final boolean value) {
+            final SharedPreferences.Editor editor = prefs().edit();
+            editor.putBoolean("not_always_hide_wk_mnemonic", value);
+            editor.apply();
+        }
+
+        /**
          * Hide WaniKani's meaning mnemonic if a user note is present
          *
          * @return the value
          */
         public static boolean getHideMeaningMnemonic() {
-            return prefs().getBoolean("hide_meaning_mnemonic", false);
+            return prefs().getBoolean("always_hide_wk_mnemonic", false) ||
+                   prefs().getBoolean("hide_meaning_mnemonic", false);
         }
 
         /**
@@ -1188,7 +1220,8 @@ public final class GlobalSettings {
          * @return the value
          */
         public static boolean getHideReadingMnemonic() {
-            return prefs().getBoolean("hide_reading_mnemonic", false);
+            return prefs().getBoolean("always_hide_wk_mnemonic", false) ||
+                   prefs().getBoolean("hide_reading_mnemonic", false);
         }
 
         /**

--- a/app/src/main/java/com/smouldering_durtles/wk/fragments/PreferencesFragment.java
+++ b/app/src/main/java/com/smouldering_durtles/wk/fragments/PreferencesFragment.java
@@ -81,7 +81,20 @@ public final class PreferencesFragment extends PreferenceFragmentCompat {
     public void onCreatePreferences(final @Nullable Bundle savedInstanceState, final @Nullable String rootKey) {
         setPreferencesFromResource(R.xml.preferences, rootKey);
 
+        // Add listener for always_hide_wk_mnemonic changes
+        final @Nullable TwoStatePreference alwaysHideWKPref = findPreference("always_hide_wk_mnemonic");
+        final @Nullable TwoStatePreference notAlwaysHideWKPref = findPreference("not_always_hide_wk_mnemonic");
 
+        if (alwaysHideWKPref != null && notAlwaysHideWKPref != null) {
+            alwaysHideWKPref.setOnPreferenceChangeListener((preference, newValue) -> {
+                boolean alwaysHide = (Boolean) newValue;
+                notAlwaysHideWKPref.setChecked(!alwaysHide);
+                return true;
+            });
+
+            // Set initial state
+            notAlwaysHideWKPref.setChecked(!alwaysHideWKPref.isChecked());
+        }
     }
 
     private void onViewCreatedBase(final View view, final @Nullable Bundle savedInstanceState) {

--- a/app/src/main/java/com/smouldering_durtles/wk/views/SubjectInfoView.java
+++ b/app/src/main/java/com/smouldering_durtles/wk/views/SubjectInfoView.java
@@ -531,8 +531,8 @@ public final class SubjectInfoView extends LinearLayout implements SubjectChange
         final boolean showReadingAnswers = getSubjectInfoDump().getShowReadingAnswers(Session.getInstance().getCurrentQuestion());
         final boolean showMeaningRelated = getSubjectInfoDump().getShowMeaningRelated(Session.getInstance().getCurrentQuestion());
         final boolean showReadingRelated = getSubjectInfoDump().getShowReadingRelated(Session.getInstance().getCurrentQuestion());
-        final boolean showMeaningMnemonic = !GlobalSettings.SubjectInfo.getHideMeaningMnemonic() || !subject.hasMeaningNote();
-        final boolean showReadingMnemonic = !GlobalSettings.SubjectInfo.getHideReadingMnemonic() || !subject.hasReadingNote();
+        final boolean showMeaningMnemonic = !GlobalSettings.SubjectInfo.getHideMeaningMnemonic() && !subject.hasMeaningNote();
+        final boolean showReadingMnemonic = !GlobalSettings.SubjectInfo.getHideReadingMnemonic() && !subject.hasReadingNote();
 
         headline.setSubject(subject);
 

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -337,16 +337,32 @@
             android:summary="This replaces tags such as &lt;kanji&gt; with appropriate colouring instead of just making the text bold"/>
 
         <SwitchPreferenceCompat
+            app:key="not_always_hide_wk_mnemonic"
+            app:title="Always hide WaniKani's own mnemonics"
+            app:singleLineTitle="false"
+            app:defaultValue="true"
+            android:persistent="false"
+            app:isPreferenceVisible="false"/>
+
+        <SwitchPreferenceCompat
+            app:key="always_hide_wk_mnemonic"
+            app:title="Always hide WaniKani's own mnemonics"
+            app:singleLineTitle="false"
+            app:defaultValue="false"/>
+
+        <SwitchPreferenceCompat
             app:key="hide_meaning_mnemonic"
             app:title="Hide WaniKani's meaning mnemonic if a user note is present"
             app:singleLineTitle="false"
-            app:defaultValue="false"/>
+            app:defaultValue="false"
+            android:dependency="not_always_hide_wk_mnemonic"/>
 
         <SwitchPreferenceCompat
             app:key="hide_reading_mnemonic"
             app:title="Hide WaniKani's reading mnemonic if a user note is present"
             app:singleLineTitle="false"
-            app:defaultValue="false"/>
+            app:defaultValue="false"
+            android:dependency="not_always_hide_wk_mnemonic"/>
 
         <SwitchPreferenceCompat
             app:key="show_legacy"


### PR DESCRIPTION
- Introduced a new setting in the app's preferences to hide WaniKani's default mnemonics.
- When enabled, only custom user mnemonics are displayed, providing a cleaner and more focused study experience for users who prefer their own mnemonics.
- Updated relevant UI components to support this feature.
- Ensured backward compatibility with previous settings.

Closes #62.