### PR TITLE
fix hide mnemonic check, hiding mnemonics, when no user note is present

### DIFF
--- a/app/src/main/java/com/smouldering_durtles/wk/GlobalSettings.java
+++ b/app/src/main/java/com/smouldering_durtles/wk/GlobalSettings.java
@@ -1227,9 +1227,9 @@ public final class GlobalSettings {
          *
          * @return the value
          */
-        public static boolean getHideMeaningMnemonic() {
+        public static boolean getHideMeaningMnemonic(final boolean hasMeaningNote) {
             return prefs().getBoolean("always_hide_wk_mnemonic", false) ||
-                   prefs().getBoolean("hide_meaning_mnemonic", false);
+                   prefs().getBoolean("hide_meaning_mnemonic", false) && hasMeaningNote;
         }
 
         /**
@@ -1237,9 +1237,9 @@ public final class GlobalSettings {
          *
          * @return the value
          */
-        public static boolean getHideReadingMnemonic() {
+        public static boolean getHideReadingMnemonic(final boolean hasReadingNote) {
             return prefs().getBoolean("always_hide_wk_mnemonic", false) ||
-                   prefs().getBoolean("hide_reading_mnemonic", false);
+                   prefs().getBoolean("hide_reading_mnemonic", false) && hasReadingNote;
         }
 
         /**

--- a/app/src/main/java/com/smouldering_durtles/wk/views/SubjectInfoView.java
+++ b/app/src/main/java/com/smouldering_durtles/wk/views/SubjectInfoView.java
@@ -531,8 +531,8 @@ public final class SubjectInfoView extends LinearLayout implements SubjectChange
         final boolean showReadingAnswers = getSubjectInfoDump().getShowReadingAnswers(Session.getInstance().getCurrentQuestion());
         final boolean showMeaningRelated = getSubjectInfoDump().getShowMeaningRelated(Session.getInstance().getCurrentQuestion());
         final boolean showReadingRelated = getSubjectInfoDump().getShowReadingRelated(Session.getInstance().getCurrentQuestion());
-        final boolean showMeaningMnemonic = !GlobalSettings.SubjectInfo.getHideMeaningMnemonic() && !subject.hasMeaningNote();
-        final boolean showReadingMnemonic = !GlobalSettings.SubjectInfo.getHideReadingMnemonic() && !subject.hasReadingNote();
+        final boolean showMeaningMnemonic = !GlobalSettings.SubjectInfo.getHideMeaningMnemonic(subject.hasMeaningNote());
+        final boolean showReadingMnemonic = !GlobalSettings.SubjectInfo.getHideReadingMnemonic(subject.hasReadingNote());
 
         headline.setSubject(subject);
 


### PR DESCRIPTION
See #122

Untested, since I don't have the whole dev environment installed. But since it's a logic error and change, it should be manageable.