### PR TITLE
Feature: Click questionText to toggle between custom font and default font (previously worked one way)

### DIFF
--- a/app/src/main/java/com/smouldering_durtles/wk/fragments/AbstractSessionFragment.java
+++ b/app/src/main/java/com/smouldering_durtles/wk/fragments/AbstractSessionFragment.java
@@ -138,7 +138,15 @@ public abstract class AbstractSessionFragment extends AbstractFragment implement
         questionText.setSubject(subject, question, session.getType());
         questionText.setMaxSize(maxWidth, maxHeight);
         questionText.setSizeForQuiz(true);
-        questionText.setOnClickListener(v -> safe(() -> questionText.setTypefaceConfiguration(TypefaceConfiguration.DEFAULT)));
+
+        // Toggle between typefaceConfiguration and DEFAULT on click
+        questionText.setOnClickListener(v -> safe(() ->
+                questionText.setTypefaceConfiguration(
+                        questionText.getTypefaceConfiguration() == TypefaceConfiguration.DEFAULT
+                                ? typefaceConfiguration
+                                : TypefaceConfiguration.DEFAULT
+                )
+        ));
 
         // Color the question type view white or black for meaning and reading respectively
         questionType.setText(question.getTitle());

--- a/app/src/main/java/com/smouldering_durtles/wk/proxy/ViewProxy.java
+++ b/app/src/main/java/com/smouldering_durtles/wk/proxy/ViewProxy.java
@@ -269,6 +269,14 @@ public final class ViewProxy {
         }
     }
 
+    public @Nullable TypefaceConfiguration getTypefaceConfiguration() {
+        final @Nullable View delegate = getDelegate();
+        if (delegate instanceof SubjectInfoButtonView) {
+            return ((SubjectInfoButtonView) delegate).getTypefaceConfiguration();
+        }
+        return null;
+    }
+
     public void setSubject(final Subject subject) {
         setSubject(subject, null, null);
     }

--- a/app/src/main/java/com/smouldering_durtles/wk/views/SubjectInfoButtonView.java
+++ b/app/src/main/java/com/smouldering_durtles/wk/views/SubjectInfoButtonView.java
@@ -489,6 +489,13 @@ public final class SubjectInfoButtonView extends View {
     }
 
     /**
+     * Get the typeface configuration for the text if this is not a radical with an image.
+     */
+    public TypefaceConfiguration getTypefaceConfiguration() {
+        return this.typefaceConfiguration;
+    }
+
+    /**
      * Get the calculated width for the view, excluding padding.
      *
      * @return the width in pixels


### PR DESCRIPTION
Hi!
Previously clicking on question switched it from custom font to default font, but clicking again did nothing. With this PR, it changes back and forth between them on each click.