### PR TITLE
Allow the app to receive a search intent, and pre-populate the search box with that text

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -114,6 +114,11 @@
             <intent-filter>
                 <action android:name="android.intent.action.SEARCH"/>
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="text/plain" />
+            </intent-filter>
             <meta-data android:name="android.app.searchable" android:resource="@xml/searchable"/>
             <meta-data android:name="android.app.default_searchable" android:value=".activities.BrowseActivity"/>
         </activity>

--- a/app/src/main/java/com/smouldering_durtles/wk/activities/AbstractActivity.java
+++ b/app/src/main/java/com/smouldering_durtles/wk/activities/AbstractActivity.java
@@ -345,6 +345,27 @@ public abstract class AbstractActivity extends AppCompatActivity implements Shar
         if (searchItem != null && searchManager != null) {
             final SearchView searchView = (SearchView) searchItem.getActionView();
             searchView.setSearchableInfo(searchManager.getSearchableInfo(new ComponentName(this, BrowseActivity.class)));
+            searchItem.setOnActionExpandListener(new MenuItem.OnActionExpandListener() {
+                @Override
+                public boolean onMenuItemActionExpand(MenuItem item) {
+                    final @Nullable AbstractFragment fragment = getCurrentFragment();
+                    if (fragment != null) {
+                        final @Nullable String query = fragment.getPrefillSearchQuery();
+                        if (query != null) {
+                            searchView.post(() -> {
+                                searchView.setIconified(false);
+                                searchView.setQuery(query, false);
+                            });
+                        }
+                    }
+                    return true;
+                }
+
+                @Override
+                public boolean onMenuItemActionCollapse(MenuItem item) {
+                    return true;
+                }
+            });
         }
 
         final @Nullable MenuItem testItem = menu.findItem(R.id.action_test);
@@ -375,10 +396,6 @@ public abstract class AbstractActivity extends AppCompatActivity implements Shar
 
         if (itemId == R.id.action_settings) {
             goToPreferencesActivity(null);
-            return true;
-        }
-        if (itemId == R.id.action_search) {
-            startSearch(null, false, null, false);
             return true;
         }
         if (itemId == R.id.action_mute) {

--- a/app/src/main/java/com/smouldering_durtles/wk/activities/BrowseActivity.java
+++ b/app/src/main/java/com/smouldering_durtles/wk/activities/BrowseActivity.java
@@ -61,6 +61,14 @@ public final class BrowseActivity extends AbstractActivity {
                 }
             }
 
+            if (Intent.ACTION_SEND.equals(getIntent().getAction()) && "text/plain".equals(getIntent().getType())) {
+                final @Nullable String sharedText = getIntent().getStringExtra(Intent.EXTRA_TEXT);
+                if (sharedText != null) {
+                    loadSearchResultFragment(null, 1, sharedText);
+                    return;
+                }
+            }
+
             final long id = getIntent().getLongExtra("id", -1);
             if (id > 0) {
                 long[] ids = getIntent().getLongArrayExtra("ids");

--- a/app/src/main/java/com/smouldering_durtles/wk/fragments/AbstractFragment.java
+++ b/app/src/main/java/com/smouldering_durtles/wk/fragments/AbstractFragment.java
@@ -310,4 +310,14 @@ public abstract class AbstractFragment extends Fragment implements Actment {
      * Update variable view state for this fragment.
      */
     public abstract void updateViews();
+
+    /**
+     * Get a query string to pre-fill the search bar when it expands,
+     * or null if no query should be pre-filled.
+     *
+     * @return the query or null
+     */
+    public @Nullable String getPrefillSearchQuery() {
+        return null;
+    }
 }

--- a/app/src/main/java/com/smouldering_durtles/wk/fragments/SearchResultFragment.java
+++ b/app/src/main/java/com/smouldering_durtles/wk/fragments/SearchResultFragment.java
@@ -266,6 +266,14 @@ public final class SearchResultFragment extends AbstractFragment {
         numHits.setTextFormat("%s: %d subject(s) found", searchDescription, adapter.getNumSubjects());
     }
 
+    @Override
+    public @Nullable String getPrefillSearchQuery() {
+        if (searchType == 1) {
+            return searchParameters;
+        }
+        return null;
+    }
+
     private void savePreset(final String name) {
         final SearchPreset preset = new SearchPreset();
         preset.name = name;


### PR DESCRIPTION
This enables a workflow whereby you can select text you're reading, share it with the app to search it in WaniKani, tap the search icon to adjust the input if needed (if for example the full word isn't on WaniKani, but a prefix of it is), and then review the word or Kanji.