### PR TITLE
Fix: Add missing Ribcage radical image

### DIFF
--- a/app/src/main/java/com/smouldering_durtles/wk/db/model/Subject.java
+++ b/app/src/main/java/com/smouldering_durtles/wk/db/model/Subject.java
@@ -1533,6 +1533,7 @@ public final class Subject implements PronunciationAudioOwner {
             case 8797: return R.drawable.radical_8797;
             case 8798: return R.drawable.radical_8798;
             case 8799: return R.drawable.radical_8799;
+            case 9452: return R.drawable.radical_9452;
             default: break;
         }
         return 0;

--- a/app/src/main/res/drawable/radical_9452.xml
+++ b/app/src/main/res/drawable/radical_9452.xml
@@ -1,0 +1,6 @@
+<vector android:height="24dp" android:viewportHeight="1000"
+    android:viewportWidth="1000" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#00000000"
+        android:pathData="M35,482.15 L966,482.15 M496.28,36 L496.28,479.15 M77.96,149 L921.96,149 M140.89,299.96 L857.78,299.96"
+        android:strokeColor="#000" android:strokeLineCap="square" android:strokeWidth="68"/>
+</vector>


### PR DESCRIPTION
Fixes #150.

Adds the vector drawable for the Ribcage radical (ID 9452) and maps it in Subject.java.