### PR TITLE
Extract haptic feedback into HapticUtil to fix vibrate() deprecation warning

### DIFF
--- a/app/src/main/java/com/smouldering_durtles/wk/fragments/AnsweredSessionFragment.java
+++ b/app/src/main/java/com/smouldering_durtles/wk/fragments/AnsweredSessionFragment.java
@@ -16,12 +16,8 @@
 
 package com.smouldering_durtles.wk.fragments;
 
-import android.content.Context;
-import android.os.Build;
 import android.os.Bundle;
-import android.os.Vibrator;
 import android.util.Log;
-import android.view.HapticFeedbackConstants;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.LinearLayout;
@@ -37,6 +33,7 @@ import com.smouldering_durtles.wk.model.DigraphMatch;
 import com.smouldering_durtles.wk.model.FloatingUiState;
 import com.smouldering_durtles.wk.model.Question;
 import com.smouldering_durtles.wk.proxy.ViewProxy;
+import com.smouldering_durtles.wk.util.HapticUtil;
 import com.smouldering_durtles.wk.util.ThemeUtil;
 import com.smouldering_durtles.wk.views.SubjectInfoView;
 import com.smouldering_durtles.wk.views.SwipingScrollView;
@@ -147,16 +144,7 @@ public final class AnsweredSessionFragment extends AbstractSessionFragment imple
             questionEdit.setBackgroundColor(ThemeUtil.getColor(R.attr.incorrectColorBackground));
             if (enable_haptic_feedback_failure()) {
                 Log.d("HapticFeedback", "Vibing");
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                    requireView().performHapticFeedback(HapticFeedbackConstants.REJECT); // Assuming REJECT is the desired feedback for a failure
-                } else {
-                    // Fallback for older API versions using Vibrator
-                    Vibrator vibrator = (Vibrator) requireContext().getSystemService(Context.VIBRATOR_SERVICE);
-                    if (vibrator != null && vibrator.hasVibrator()) {
-                        // Vibrate for 200 milliseconds for a slightly longer feedback on failure
-                        vibrator.vibrate(300);
-                    }
-                }
+                HapticUtil.onWrong(requireView(), requireContext());
             }
         }
 

--- a/app/src/main/java/com/smouldering_durtles/wk/fragments/UnansweredSessionFragment.java
+++ b/app/src/main/java/com/smouldering_durtles/wk/fragments/UnansweredSessionFragment.java
@@ -16,10 +16,8 @@
 
 package com.smouldering_durtles.wk.fragments;
 
-import android.content.Context;
 import android.os.Build;
 import android.os.Bundle;
-import android.os.Vibrator;
 import android.text.Editable;
 import android.text.InputType;
 import android.text.SpannableString;
@@ -27,7 +25,6 @@ import android.text.Spanned;
 import android.text.TextWatcher;
 import android.util.Log;
 import android.view.Gravity;
-import android.view.HapticFeedbackConstants;
 import android.view.KeyEvent;
 import android.view.View;
 import android.view.ViewGroup;
@@ -48,6 +45,7 @@ import com.smouldering_durtles.wk.model.AnswerVerdict;
 import com.smouldering_durtles.wk.model.FloatingUiState;
 import com.smouldering_durtles.wk.model.Question;
 import com.smouldering_durtles.wk.proxy.ViewProxy;
+import com.smouldering_durtles.wk.util.HapticUtil;
 import com.smouldering_durtles.wk.util.Logger;
 import com.smouldering_durtles.wk.util.PseudoIme;
 
@@ -300,16 +298,7 @@ public final class UnansweredSessionFragment extends AbstractSessionFragment {
                 showSoftInput(questionEdit);
                 if (enable_haptic_feedback_failure()) {
                     Log.d("HapticFeedback", "Vibing");
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                        requireView().performHapticFeedback(HapticFeedbackConstants.REJECT); // Assuming REJECT is the desired feedback for a failure
-                    } else {
-                        // Fallback for older API versions using Vibrator
-                        Vibrator vibrator = (Vibrator) requireContext().getSystemService(Context.VIBRATOR_SERVICE);
-                        if (vibrator != null && vibrator.hasVibrator()) {
-                            // Vibrate for 200 milliseconds for a slightly longer feedback on failure
-                            vibrator.vibrate(300);
-                        }
-                    }
+                    HapticUtil.onWrong(requireView(), requireContext());
                 }
             }
         }));
@@ -472,16 +461,7 @@ public final class UnansweredSessionFragment extends AbstractSessionFragment {
                 final AnswerVerdict verdict = session.submit(match);
 
                 if (verdict.isOk() && enable_haptic_feedback_success()) {
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                        requireView().performHapticFeedback(HapticFeedbackConstants.CONFIRM);
-                    } else {
-                        // Fallback for older API versions using Vibrator
-                        Vibrator vibrator = (Vibrator) requireContext().getSystemService(Context.VIBRATOR_SERVICE);
-                        if (vibrator != null && vibrator.hasVibrator()) {
-                            // Vibrate for 100 milliseconds as a short feedback
-                            vibrator.vibrate(100);
-                        }
-                    }
+                    HapticUtil.onCorrect(requireView(), requireContext());
                 }
 
                 if (verdict.isRetry()) {
@@ -493,16 +473,7 @@ public final class UnansweredSessionFragment extends AbstractSessionFragment {
                     questionEdit.setTag(true);
                     if (enable_haptic_feedback_failure()) {
                         Log.d("HapticFeedback", "Vibing");
-                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                            requireView().performHapticFeedback(HapticFeedbackConstants.REJECT); // Assuming REJECT is the desired feedback for a failure
-                        } else {
-                            // Fallback for older API versions using Vibrator
-                            Vibrator vibrator = (Vibrator) requireContext().getSystemService(Context.VIBRATOR_SERVICE);
-                            if (vibrator != null && vibrator.hasVibrator()) {
-                                // Vibrate for 200 milliseconds for a slightly longer feedback on failure
-                                vibrator.vibrate(200);
-                            }
-                        }
+                        HapticUtil.onRetry(requireView(), requireContext());
                     }
                 }
             }

--- a/app/src/main/java/com/smouldering_durtles/wk/util/HapticUtil.java
+++ b/app/src/main/java/com/smouldering_durtles/wk/util/HapticUtil.java
@@ -1,0 +1,44 @@
+package com.smouldering_durtles.wk.util;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.os.Build;
+import android.os.VibrationEffect;
+import android.os.Vibrator;
+import android.view.HapticFeedbackConstants;
+import android.view.View;
+
+public final class HapticUtil {
+    private HapticUtil() {}
+
+    @SuppressLint("NewApi")
+    public static void onCorrect(final View view, final Context context) {
+        feedback(view, context, HapticFeedbackConstants.CONFIRM, 100);
+    }
+
+    @SuppressLint("NewApi")
+    public static void onWrong(final View view, final Context context) {
+        feedback(view, context, HapticFeedbackConstants.REJECT, 300);
+    }
+
+    @SuppressLint("NewApi")
+    public static void onRetry(final View view, final Context context) {
+        feedback(view, context, HapticFeedbackConstants.REJECT, 200);
+    }
+
+    @SuppressWarnings("deprecation")
+    private static void feedback(final View view, final Context context, final int constant, final long fallbackMs) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            view.performHapticFeedback(constant);
+        } else {
+            final Vibrator vibrator = (Vibrator) context.getSystemService(Context.VIBRATOR_SERVICE);
+            if (vibrator != null && vibrator.hasVibrator()) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                    vibrator.vibrate(VibrationEffect.createOneShot(fallbackMs, VibrationEffect.DEFAULT_AMPLITUDE));
+                } else {
+                    vibrator.vibrate(fallbackMs);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What

`Vibrator.vibrate(long)` has been deprecated since API 26 and was called inline at four sites across `AnsweredSessionFragment` and `UnansweredSessionFragment`, so the deprecation warning fired at each.

This extracts the haptic logic into a single `HapticUtil` helper (`onCorrect` / `onWrong` / `onRetry`):

- The fallback uses `VibrationEffect.createOneShot` on API 26–29, silencing the deprecation warning.
- The pre-26 `vibrate(long)` path is `@SuppressWarnings`-scoped in one place instead of scattered across the fragments.
- The four inline `performHapticFeedback` / `Vibrator` blocks are replaced with single-line calls.

## Behavior

Preserved exactly — correct = 100ms, wrong = 300ms, retry = 200ms, using `HapticFeedbackConstants.CONFIRM`/`REJECT` on API R+ with the `Vibrator` fallback below.

## Testing

`./gradlew assembleDebug` passes; no new warnings.