### PR TITLE
Ask the user for notification permission to fix notification on Android 13+

### DIFF
--- a/app/src/main/java/com/smouldering_durtles/wk/GlobalSettings.java
+++ b/app/src/main/java/com/smouldering_durtles/wk/GlobalSettings.java
@@ -642,6 +642,7 @@ public final class GlobalSettings {
         Tutorials.setSearchResultDismissed(false);
         Tutorials.setStartSelfStudyDismissed(false);
         Tutorials.setSessionLogDismissed(false);
+        Tutorials.setNotificationPermissionAsked(false);
     }
 
     /**
@@ -3524,6 +3525,16 @@ public final class GlobalSettings {
         public static void setSessionLogDismissed(final boolean value) {
             final SharedPreferences.Editor editor = prefs().edit();
             editor.putBoolean("session_log_dismissed", value);
+            editor.apply();
+        }
+
+        public static boolean getNotificationPermissionAsked() {
+            return prefs().getBoolean("notification_permission_asked", false);
+        }
+
+        public static void setNotificationPermissionAsked(final boolean value) {
+            final SharedPreferences.Editor editor = prefs().edit();
+            editor.putBoolean("notification_permission_asked", value);
             editor.apply();
         }
     }

--- a/app/src/main/java/com/smouldering_durtles/wk/activities/MainActivity.java
+++ b/app/src/main/java/com/smouldering_durtles/wk/activities/MainActivity.java
@@ -19,7 +19,14 @@ package com.smouldering_durtles.wk.activities;
 import static com.smouldering_durtles.wk.util.ObjectSupport.runAsync;
 import static com.smouldering_durtles.wk.util.ObjectSupport.safe;
 
+import android.Manifest;
+import android.content.pm.PackageManager;
+import android.os.Build;
 import android.os.Bundle;
+
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
+import androidx.core.content.ContextCompat;
 
 import com.smouldering_durtles.wk.GlobalSettings;
 import com.smouldering_durtles.wk.R;
@@ -74,6 +81,7 @@ public final class MainActivity extends AbstractActivity {
     private final ViewProxy apiErrorView = new ViewProxy();
     private final ViewProxy apiKeyRejectedView = new ViewProxy();
     private final ViewProxy keyboardHelpView = new ViewProxy();
+    private @Nullable ActivityResultLauncher<String> notificationPermissionLauncher = null;
 
     /**
      * The constructor.
@@ -84,6 +92,12 @@ public final class MainActivity extends AbstractActivity {
 
     @Override
     protected void onCreateLocal(final @Nullable Bundle savedInstanceState) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            notificationPermissionLauncher = registerForActivityResult(
+                    new ActivityResultContracts.RequestPermission(),
+                    isGranted -> GlobalSettings.Tutorials.setNotificationPermissionAsked(true));
+        }
+
         apiErrorView.setDelegate(this, R.id.apiErrorView);
         apiKeyRejectedView.setDelegate(this, R.id.apiKeyRejectedView);
         keyboardHelpView.setDelegate(this, R.id.keyboardHelpView);
@@ -194,6 +208,15 @@ public final class MainActivity extends AbstractActivity {
 
     @Override
     protected void onResumeLocal() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
+                && notificationPermissionLauncher != null
+                && !GlobalSettings.Tutorials.getNotificationPermissionAsked()
+                && ContextCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS)
+                        != PackageManager.PERMISSION_GRANTED) {
+            GlobalSettings.Tutorials.setNotificationPermissionAsked(true);
+            notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS);
+        }
+
         BackgroundAlarmReceiver.scheduleOrCancelAlarm();
         BackgroundSyncWorker.scheduleOrCancelWork();
 

--- a/app/src/main/java/com/smouldering_durtles/wk/fragments/PreferencesFragment.java
+++ b/app/src/main/java/com/smouldering_durtles/wk/fragments/PreferencesFragment.java
@@ -16,10 +16,16 @@
 
 package com.smouldering_durtles.wk.fragments;
 
+import android.Manifest;
 import android.app.Activity;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.os.Build;
 import android.os.Bundle;
+import android.provider.Settings;
+
+import androidx.core.content.ContextCompat;
+
 import android.text.InputType;
 import android.view.View;
 import android.widget.Toast;
@@ -127,8 +133,7 @@ public final class PreferencesFragment extends PreferenceFragmentCompat {
                                 ((TwoStatePreference) preference).setChecked(true);
                             })).create().show();
                     return false;
-                }
-                else {
+                } else {
                     setVisibility("advanced_lesson_settings", enabled);
                     setVisibility("advanced_review_settings", enabled);
                     setVisibility("advanced_self_study_settings", enabled);
@@ -167,6 +172,22 @@ public final class PreferencesFragment extends PreferenceFragmentCompat {
                     })).create().show();
             return true;
         }));
+
+        final @Nullable Preference grantNotificationPref = findPreference("grant_notification_permission");
+        if (grantNotificationPref != null) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
+                    && ContextCompat.checkSelfPermission(requireContext(), Manifest.permission.POST_NOTIFICATIONS)
+                    != PackageManager.PERMISSION_GRANTED) {
+                grantNotificationPref.setOnPreferenceClickListener(preference -> safe(false, () -> {
+                    final Intent intent = new Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS);
+                    intent.putExtra(Settings.EXTRA_APP_PACKAGE, requireContext().getPackageName());
+                    startActivity(intent);
+                    return true;
+                }));
+            } else {
+                grantNotificationPref.setVisible(false);
+            }
+        }
 
         setOnPreferenceClick("backup_settings", preference -> {
             new AlertDialog.Builder(preference.getContext())

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -760,7 +760,13 @@
 
     <PreferenceScreen
         app:key="other_settings"
-        app:title="Other settings">
+        app:title="Notifications and other settings">
+
+        <Preference
+            app:key="grant_notification_permission"
+            app:title="Grant notification permission"
+            app:summary="Open system settings to allow this app to send notifications"
+            app:singleLineTitle="false"/>
 
         <SwitchPreferenceCompat
             app:key="enable_notifications"


### PR DESCRIPTION
## What

On Android 13+ (TIRAMISU), `POST_NOTIFICATIONS` is a runtime permission — the manifest declaration alone isn't enough, so notifications silently never appear unless the app asks. This adds that prompt.

- **`MainActivity`** registers a `RequestPermission` launcher (API 33+) and, on resume, requests `POST_NOTIFICATIONS` once if it hasn't been asked yet and isn't already granted.
- **`GlobalSettings.Tutorials`** stores a `notification_permission_asked` flag so the prompt only fires once, and resets it with the other tutorial/prompt flags.
- **`PreferencesFragment`** adds a "Grant notification permission" preference that deep-links to the system notification settings; it's hidden when the permission is already granted or on pre-33 devices.
- **`preferences.xml`** adds that preference and renames the screen to "Notifications and other settings".

All new behavior is gated behind `Build.VERSION_CODES.TIRAMISU`, so pre-13 behavior is unchanged. `POST_NOTIFICATIONS` is already declared in the manifest.

## Testing

`./gradlew assembleDebug` passes.