### PR TITLE
Target Android 17 and keep the soft keyboard open across rotation

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,8 +4,8 @@ android {
     defaultConfig {
         applicationId "com.smouldering_durtles.wk"
         minSdkVersion 21
-        targetSdkVersion 36
-        compileSdk = 36
+        targetSdkVersion 37
+        compileSdk = 37
         versionCode 89
         versionName '1.2.8'
         multiDexEnabled true

--- a/app/src/main/java/com/smouldering_durtles/wk/fragments/AbstractFragment.java
+++ b/app/src/main/java/com/smouldering_durtles/wk/fragments/AbstractFragment.java
@@ -21,6 +21,7 @@ import android.content.Context;
 import android.content.res.Configuration;
 import android.os.Bundle;
 import android.view.View;
+import android.view.ViewTreeObserver;
 import android.view.inputmethod.InputMethodManager;
 
 import androidx.appcompat.widget.Toolbar;
@@ -30,6 +31,7 @@ import com.smouldering_durtles.wk.Actment;
 import com.smouldering_durtles.wk.activities.AbstractActivity;
 import com.smouldering_durtles.wk.db.model.Subject;
 import com.smouldering_durtles.wk.enums.FragmentTransitionAnimation;
+import com.smouldering_durtles.wk.util.Logger;
 
 import java.util.List;
 
@@ -41,10 +43,23 @@ import static com.smouldering_durtles.wk.util.ObjectSupport.safe;
  * Abstract superclass for the various quiz fragments.
  */
 public abstract class AbstractFragment extends Fragment implements Actment {
+    private static final Logger LOGGER = Logger.get(AbstractFragment.class);
+
     /**
      * Is interaction with e.g. buttons on this display currently enabled?.
      */
     protected boolean interactionEnabled = true;
+
+    /**
+     * A window focus listener waiting to show the IME, set when showSoftInput() was called while
+     * the window did not have focus yet. Null when no request is pending.
+     */
+    private @Nullable ViewTreeObserver.OnWindowFocusChangeListener pendingSoftInputListener = null;
+
+    /**
+     * The view that pendingSoftInputListener will show the IME for. Null when no request is pending.
+     */
+    private @Nullable View pendingSoftInputView = null;
 
     /**
      * The constructor.
@@ -73,6 +88,13 @@ public abstract class AbstractFragment extends Fragment implements Actment {
     }
 
     @Override
+    public final void onDestroyView() {
+        // A deferred IME request must not outlive the view it targets.
+        removePendingSoftInputListener();
+        super.onDestroyView();
+    }
+
+    @Override
     public final void onViewCreated(final View view, final @Nullable Bundle savedInstanceState) {
         safe(() -> {
             super.onViewCreated(view, savedInstanceState);
@@ -93,6 +115,10 @@ public abstract class AbstractFragment extends Fragment implements Actment {
      * Hide the soft keyboard.
      */
     protected final void hideSoftInput() {
+        // A show request deferred until the window regains focus must not outlive the decision to
+        // hide the keyboard - otherwise it fires later and pops the IME back up.
+        removePendingSoftInputListener();
+
         safe(() -> {
             final @Nullable AbstractActivity activity = getAbstractActivity();
             if (activity == null) {
@@ -114,16 +140,74 @@ public abstract class AbstractFragment extends Fragment implements Actment {
     /**
      * Show the soft keyboard.
      *
+     * <p>The IME can only be shown for a view whose window currently has focus. This method is
+     * routinely called from onResume, which runs <em>before</em> the window regains focus, so the
+     * request is deferred to the next window focus gain when needed. Until Android 17 the system
+     * restored the IME's previous visibility across a configuration change by itself, which masked
+     * the early request being dropped; from Android 17 on it does not, so the deferral is what
+     * keeps the keyboard up across a rotation.
+     *
      * @param view the view to attach the IME to.
      */
     @SuppressWarnings("MethodMayBeStatic")
     protected final void showSoftInput(final View view) {
-        safe(() -> {
-            final @Nullable InputMethodManager imm = (InputMethodManager) view.getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
-            if (imm != null) {
-                imm.showSoftInput(view, InputMethodManager.SHOW_IMPLICIT);
+        // This request supersedes any earlier deferred one. A stale listener must not survive: it
+        // only fires on a focus *change*, so one registered for a view that turned out to be
+        // attached to an already-focused window never fires at all, and would otherwise sit there
+        // until the next unrelated focus loss and regain - popping the IME up out of nowhere.
+        removePendingSoftInputListener();
+
+        if (view.hasWindowFocus()) {
+            requestSoftInput(view);
+            return;
+        }
+
+        final ViewTreeObserver.OnWindowFocusChangeListener listener = hasFocus -> {
+            if (!hasFocus) {
+                return;
             }
-        });
+            removePendingSoftInputListener();
+            requestSoftInput(view);
+        };
+        pendingSoftInputListener = listener;
+        pendingSoftInputView = view;
+        view.getViewTreeObserver().addOnWindowFocusChangeListener(listener);
+    }
+
+    /**
+     * Ask the IME to show itself for a view that already has window focus.
+     *
+     * @param view the view to attach the IME to.
+     */
+    private static void requestSoftInput(final View view) {
+        final @Nullable InputMethodManager imm = (InputMethodManager) view.getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
+        if (imm == null) {
+            LOGGER.info("No InputMethodManager available, cannot show the soft keyboard");
+            return;
+        }
+        if (!imm.showSoftInput(view, InputMethodManager.SHOW_IMPLICIT)) {
+            // Not fatal - the user can still tap the field - but it means the answer field is
+            // silently unusable, so it must not disappear without a trace.
+            LOGGER.info("Request to show the soft keyboard was refused (window focus: %s, view focus: %s)",
+                    view.hasWindowFocus(), view.hasFocus());
+        }
+    }
+
+    /**
+     * Detach the pending window focus listener, if any, and forget it.
+     */
+    private void removePendingSoftInputListener() {
+        final @Nullable ViewTreeObserver.OnWindowFocusChangeListener listener = pendingSoftInputListener;
+        final @Nullable View view = pendingSoftInputView;
+        pendingSoftInputListener = null;
+        pendingSoftInputView = null;
+        if (listener == null || view == null) {
+            return;
+        }
+        final ViewTreeObserver observer = view.getViewTreeObserver();
+        if (observer.isAlive()) {
+            observer.removeOnWindowFocusChangeListener(listener);
+        }
     }
 
     @Override


### PR DESCRIPTION
Targets Android 17 (API 37) and fixes the soft keyboard disappearing on rotation there.

## Maintain keyboard open state in Android 17

Android 17 stopped restoring the IME's previous visibility across a configuration change the app doesn't handle. Rotating mid-review now drops the keyboard, so you have to tap the answer field again on every rotation.

The app already asks for the keyboard explicitly — `SessionActivity.updateFragment()` calls `showOrHideSoftInput()`, which reaches `AbstractFragment.showSoftInput()`. But that runs from `onResume`, which is *before* the window regains focus, and `InputMethodManager.showSoftInput()` is refused for a view whose window isn't focused. It returned `false` and the result was discarded, so the request had always been a silent no-op on that path — it simply never mattered while the system restored visibility on its own.

`showSoftInput()` now keeps the direct call when the window already has focus, and otherwise defers to a one-shot `ViewTreeObserver.OnWindowFocusChangeListener` that re-issues the request the moment focus arrives.

Lifecycle of that deferred request — it is retired by any of:

- its own firing (removes itself on first focus gain),
- a subsequent `showSoftInput()` (a new request supersedes the old one),
- `hideSoftInput()` (so a hide always wins over a pending show),
- `onDestroyView()` (so it can't outlive the view it targets).

The third and fourth matter in practice. `SearchResultFragment` both shows and hides on the same instance, and a listener registered for a view that turns out to be attached to an already-focused window never fires at all — without the supersede/cancel rules it would sit there and pop the IME up on the next unrelated focus change.

Two smaller changes in the same method, both about the failure being invisible:

- the `safe()` wrapper is gone from `showSoftInput` — it was swallowing the very failure that made this hard to see;
- `showSoftInput()`'s boolean return is now checked and logged with the window/view focus state, so a future refusal leaves a trace instead of a mystery.

`hideSoftInput` keeps its `safe()` wrapper; only the show path changed.

## Target Android 17

`targetSdkVersion` and `compileSdk` 36 → 37.

I also checked the other Android 17 all-apps behaviour changes against this codebase; nothing else needs action here. Worth knowing about, though not blocking:

- **Implicit URI grants** (enforced in Android 18) — both `ACTION_SEND` sites in `DataImportExportActivity` already set `FLAG_GRANT_READ_URI_PERMISSION` explicitly, so they're already compliant.
- **Background audio hardening** — `AudioUtil` only plays during a foreground session and already requests/abandons focus properly.
- **Keystore limits** — one key (`MasterKey.DEFAULT_MASTER_KEY_ALIAS`); the limit is 50,000.
- **App memory limits** — a memory-limiter kill is not a crash, so it leaves no crash report. Reading `ApplicationExitInfo` on next launch would surface those (and ANRs, and low-memory kills). Out of scope here.

## Testing

- `./gradlew assembleDebug` green against SDK 37, on this branch as it stands.
- The fix was developed against a physical Pixel 10 Pro running Android 17 (API 37), where the bug reproduces. Manual rotation testing is being done on that device; the paths worth exercising are a review question (rotate, keyboard should stay up), and the `SearchResultFragment` search box, which is the one place that both shows and hides on the same fragment instance.
- No automated test covers this — the behaviour is IME/window-focus timing and needs a device.
